### PR TITLE
Add JSON output support to list commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,78 @@ Cache entries Fields
   count       - Use Count [num]
 ```
 
+#### JSON report output
+
+The reporting commands can also produce output in JSON notation. The
+output is an array of JSON objects mapping field names to values. The
+full field name including the type prefix is used to ensure keys are
+unambiguous.
+
+```
+# boom list --json
+{
+    "Entries": [
+        {
+            "entry_bootid": "635ed15b411495cffa0c1eece74d3756278f484a",
+            "param_version": "6.8.9-300.fc40.x86_64",
+            "profile_osname": "Fedora Linux",
+            "param_rootdev": "/dev/mapper/fedora-root"
+        },
+        {
+            "entry_bootid": "995b87eac66fa6b4507e4c5dbd8a30e196b13e2c",
+            "param_version": "6.8.9-300.fc40.x86_64",
+            "profile_osname": "Fedora Linux",
+            "param_rootdev": "/dev/fedora/root-snapset_upgrade_1719340050_-"
+        },
+        {
+            "entry_bootid": "029c3078f83df79bfc2240223c6f79c648b2fce3",
+            "param_version": "6.8.9-300.fc40.x86_64",
+            "profile_osname": "Fedora Linux",
+            "param_rootdev": "/dev/fedora/root"
+        }
+    ]
+}
+```
+
+To include all fields for a given prefix use the special field name
+`all`:
+
+```
+# boom list --json -o+entry_all,param_all,profile_all
+{
+    "Entries": [
+        {
+            "entry_bootid": "635ed15b411495cffa0c1eece74d3756278f484a",
+            "param_version": "6.8.9-300.fc40.x86_64",
+            "profile_osname": "Fedora Linux",
+            "param_rootdev": "/dev/mapper/fedora-root",
+            "entry_title": "Fedora Linux (6.8.9-300.fc40.x86_64) 40 (Server Edition)",
+            "entry_options": "root=/dev/mapper/fedora-root ro rd.lvm.lv=fedora/root rhgb quiet ",
+            "entry_kernel": "/vmlinuz-6.8.9-300.fc40.x86_64",
+            "entry_initramfs": "/initramfs-6.8.9-300.fc40.x86_64.img",
+            "entry_machineid": "5d1e621b0c1349aea3bd47e4bb619024",
+            "entry_entrypath": "/boot/loader/entries/5d1e621b0c1349aea3bd47e4bb619024-6.8.9-300.fc40.x86_64.conf",
+            "entry_entryfile": "5d1e621b0c1349aea3bd47e4bb619024-6.8.9-300.fc40.x86_64.conf",
+            "entry_readonly": true,
+            "param_rootlv": "fedora/root",
+            "param_subvolpath": "",
+            "param_subvolid": -1,
+            "profile_osid": "5ea08f4d8c4d6fbdfdb2c0b79829e7ff4dfce7d4",
+            "profile_osshortname": "fedora",
+            "profile_osversion": "40 (Server Edition)",
+            "profile_osversion_id": "40",
+            "profile_unamepattern": "fc40",
+            "profile_kernelpattern": "/vmlinuz-%{version}",
+            "profile_initrdpattern": "/initramfs-%{version}.img",
+            "profile_lvm2opts": "rd.lvm.lv=%{lvm_root_lv}",
+            "profile_btrfsopts": "rootflags=%{btrfs_subvolume}",
+            "profile_options": "root=%{root_device} ro %{root_opts} rhgb quiet",
+            "profile_profilepath": "/boot/boom/profiles/5ea08f4d8c4d6fbdfdb2c0b79829e7ff4dfce7d4-fedora40.profile"
+        }
+    ]
+}
+```
+
 ### Getting help
 
 Help is available for the `boom` command and each command line option.

--- a/README.md
+++ b/README.md
@@ -334,9 +334,9 @@ Detailed information on selected cache entries is provided by the
 
 ### Reporting commands
 
-The `boom entry list` and `boom host|profile list` commands generate
-a tabular report as output. To control the list of displayed fields
-use the `-o/--options FIELDS` argument:
+The `boom entry list` and `boom host|profile list`, and `boom cache
+list` commands generate a tabular report as output. To control the
+list of displayed fields use the `-o/--options FIELDS` argument:
 
 ```
 boom list -oboot_id,version
@@ -365,6 +365,14 @@ a559d3a 2.6.32-232.el6           98c3edb Red Hat Enterprise Linux Server 6 (Serv
 d85f2c3 3.10.1-1.el7             3fc389b Red Hat Enterprise Linux Server 7.2 (Maipo) /boot/vmlinuz-3.10.1-1.el7           /boot/initramfs-3.10.1-1.el7.img
 d85f2c3 3.10.1-1.el7             3fc389b Red Hat Enterprise Linux Server 7.2 (Maipo) /boot/vmlinuz-3.10.1-1.el7           /boot/initramfs-3.10.1-1.el7.img
 e19586b 7.7.7                    3fc389b Red Hat Enterprise Linux Server 7.2 (Maipo) /boot/vmlinuz-7.7.7                  /boot/initramfs-7.7.7.img
+```
+
+```
+boom list -o+title
+BootID  Version                  Name                     RootDevice                                    Title
+635ed15 6.8.9-300.fc40.x86_64    Fedora Linux             /dev/mapper/fedora-root                       Fedora Linux (6.8.9-300.fc40.x86_64) 40 (Server Edition)
+995b87e 6.8.9-300.fc40.x86_64    Fedora Linux             /dev/fedora/root-snapset_upgrade_1719340050_- Snapshot upgrade 2024-06-25 19:27:30 (6.8.9-300.fc40.x86_64)
+029c307 6.8.9-300.fc40.x86_64    Fedora Linux             /dev/fedora/root                              Revert upgrade 2024-06-25 19:27:30 (6.8.9-300.fc40.x86_64)
 ```
 
 To display the available fields for either report use the field
@@ -441,6 +449,20 @@ Host profiles Fields
   profilepath   - On-disk profile path [str]
   addopts       - Added Options [str]
   delopts       - Deleted Options [str]
+```
+
+`Cache` fields:
+```
+Cache entries Fields
+--------------------
+  imgid       - Image identifier [sha]
+  path        - Image path [str]
+  mode        - Path mode [str]
+  uid         - User ID [num]
+  gid         - Group ID [num]
+  ts          - Timestamp [num]
+  state       - State [str]
+  count       - Use Count [num]
 ```
 
 ### Getting help

--- a/boom/command.py
+++ b/boom/command.py
@@ -3726,6 +3726,9 @@ def _report_opts_from_args(cmd_args):
     if not cmd_args:
         return opts
 
+    if cmd_args.json:
+        opts.json = True
+
     if cmd_args.rows:
         opts.columns_as_rows = True
 
@@ -4095,7 +4098,11 @@ def main(args):
         help="A pattern for generating initramfs paths",
         metavar="PATTERN",
     )
-    parser.add_argument(
+    format_group = parser.add_mutually_exclusive_group()
+    format_group.add_argument(
+        "--json", action="store_true", help="Output report as JSON"
+    )
+    format_group.add_argument(
         "--rows", action="store_true", help="Output report columnes as rows"
     )
     parser.add_argument(

--- a/man/man8/boom.8
+++ b/man/man8/boom.8
@@ -180,6 +180,15 @@ Boom \(em linux boot manager
 .  IR initrd_path ]
 .  RB [ --btrfs-subvol
 .  IR subvol ]
+.  RB [ --nameprefixes ]
+.  RB [ --noheadings ]
+.  RB [ --options
+.  IR fields ]
+.  RB [ --sort
+.  IR fields ]
+.  RB [ --rows | --json ]
+.  RB [ --separator
+.  IR separator ]
 .  ad b
 ..
 .CMD_ENTRY_LIST
@@ -324,6 +333,15 @@ Boom \(em linux boot manager
 .  IR osshortname ]
 .  RB [ --os-version
 .  IR version ]
+.  RB [ --nameprefixes ]
+.  RB [ --noheadings ]
+.  RB [ --options
+.  IR fields ]
+.  RB [ --sort
+.  IR fields ]
+.  RB [ --rows | --json ]
+.  RB [ --separator
+.  IR separator ]
 .  ad b
 ..
 .CMD_PROFILE_LIST
@@ -480,6 +498,15 @@ Boom \(em linux boot manager
 .  IR btrfs_opts ]
 .  RB [ --os-options
 .  IR os_options ]
+.  RB [ --nameprefixes ]
+.  RB [ --noheadings ]
+.  RB [ --options
+.  IR fields ]
+.  RB [ --sort
+.  IR fields ]
+.  RB [ --rows | --json ]
+.  RB [ --separator
+.  IR separator ]
 .  ad b
 ..
 .CMD_HOST_LIST
@@ -597,6 +624,15 @@ Boom \(em linux boot manager
 .  RB [ --initrd
 .  IR initrd_path ]
 .  ad b
+.  RB [ --nameprefixes ]
+.  RB [ --noheadings ]
+.  RB [ --options
+.  IR fields ]
+.  RB [ --sort
+.  IR fields ]
+.  RB [ --rows | --json ]
+.  RB [ --separator
+.  IR separator ]
 ..
 .CMD_CACHE_LIST
 .
@@ -846,6 +882,11 @@ An OS profile template used to generate initial ramfs image paths.
 .BR --rows
 .br
 Output report columns as rows.
+.
+.HP
+.BR --json
+.br
+Output reports in JSON notation
 .
 .HP
 .BR --separator

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -96,6 +96,7 @@ class MockArgs(object):
     identifier = ""
     initramfs_pattern = ""
     initrd = ""
+    json = False
     kernel_pattern = ""
     label = ""
     linux = ""


### PR DESCRIPTION
```
# boom list --json
{
    "Entries": [
        {
            "entry_bootid": "635ed15b411495cffa0c1eece74d3756278f484a",
            "param_version": "6.8.9-300.fc40.x86_64",
            "profile_osname": "Fedora Linux",
            "param_rootdev": "/dev/mapper/fedora-root"
        }, 
        {
            "entry_bootid": "995b87eac66fa6b4507e4c5dbd8a30e196b13e2c",
            "param_version": "6.8.9-300.fc40.x86_64",
            "profile_osname": "Fedora Linux",
            "param_rootdev": "/dev/fedora/root-snapset_upgrade_1719340050_-"
        },
        {
            "entry_bootid": "029c3078f83df79bfc2240223c6f79c648b2fce3",
            "param_version": "6.8.9-300.fc40.x86_64",
            "profile_osname": "Fedora Linux",
            "param_rootdev": "/dev/fedora/root"
        } 
    ]
}
# boom list --json -o+entry_all,param_all,profile_all
{
    "Entries": [
        {
            "entry_bootid": "635ed15b411495cffa0c1eece74d3756278f484a",
            "param_version": "6.8.9-300.fc40.x86_64",
            "profile_osname": "Fedora Linux",
            "param_rootdev": "/dev/mapper/fedora-root",
            "entry_title": "Fedora Linux (6.8.9-300.fc40.x86_64) 40 (Server Edition)",
            "entry_options": "root=/dev/mapper/fedora-root ro rd.lvm.lv=fedora/root rhgb quiet ",
            "entry_kernel": "/vmlinuz-6.8.9-300.fc40.x86_64",
            "entry_initramfs": "/initramfs-6.8.9-300.fc40.x86_64.img",
            "entry_machineid": "5d1e621b0c1349aea3bd47e4bb619024",
            "entry_entrypath": "/boot/loader/entries/5d1e621b0c1349aea3bd47e4bb619024-6.8.9-300.fc40.x86_64.conf",
            "entry_entryfile": "5d1e621b0c1349aea3bd47e4bb619024-6.8.9-300.fc40.x86_64.conf",
            "entry_readonly": true,
            "param_rootlv": "fedora/root",
            "param_subvolpath": "",
            "param_subvolid": -1,
            "profile_osid": "5ea08f4d8c4d6fbdfdb2c0b79829e7ff4dfce7d4",
            "profile_osshortname": "fedora",
            "profile_osversion": "40 (Server Edition)",
            "profile_osversion_id": "40",
            "profile_unamepattern": "fc40",
            "profile_kernelpattern": "/vmlinuz-%{version}",
            "profile_initrdpattern": "/initramfs-%{version}.img",
            "profile_lvm2opts": "rd.lvm.lv=%{lvm_root_lv}",
            "profile_btrfsopts": "rootflags=%{btrfs_subvolume}",
            "profile_options": "root=%{root_device} ro %{root_opts} rhgb quiet",
            "profile_profilepath": "/boot/boom/profiles/5ea08f4d8c4d6fbdfdb2c0b79829e7ff4dfce7d4-fedora40.profile"
        }
    ]
}
```
