### PR TITLE
boom: fix --backup of modified images

### DIFF
--- a/boom/_boom.py
+++ b/boom/_boom.py
@@ -581,6 +581,7 @@ class Selection(object):
 
     # Cache fields
     path = None
+    orig_path = None
     img_id = None
 
     #: Selection criteria applying to BootEntry objects
@@ -632,7 +633,15 @@ class Selection(object):
     ]
 
     #: Cache selection supports a subset of entry_attrs
-    cache_attrs = ["version", "linux", "initrd", "path", "timestamp", "img_id"]
+    cache_attrs = [
+        "version",
+        "linux",
+        "initrd",
+        "path",
+        "orig_path",
+        "timestamp",
+        "img_id",
+    ]
 
     all_attrs = entry_attrs + params_attrs + profile_attrs + host_attrs + cache_attrs
 
@@ -693,6 +702,7 @@ class Selection(object):
         host_add_opts=None,
         host_del_opts=None,
         path=None,
+        orig_path=None,
         timestamp=None,
         img_id=None,
     ):
@@ -729,6 +739,7 @@ class Selection(object):
         :param host_add_opts: Host add options to match
         :param host_del_opts: Host del options to match
         :param path: An cache image path to match
+        :param orig_path: A cache origin path to match
         :param timestamp: A cache entry timestamp to match
         :param img_id: A cache image identifier to match
         :returns: A new Selection instance
@@ -762,6 +773,7 @@ class Selection(object):
         self.host_add_opts = host_add_opts
         self.host_del_opts = host_del_opts
         self.path = path
+        self.orig_path = orig_path
         self.timestamp = timestamp
         self.img_id = img_id
 

--- a/boom/command.py
+++ b/boom/command.py
@@ -895,7 +895,7 @@ def _cache_image(img_path, backup):
         else:
             ce = cache_path(img_path)
     except (OSError, ValueError) as e:
-        _log_error("Could not cache path %s: %s" % (img_path, e))
+        _log_error("Could not cache path %s" % img_path)
         raise e
     return ce.path
 

--- a/boom/command.py
+++ b/boom/command.py
@@ -880,24 +880,6 @@ I_BACKUP = "backup"
 #
 
 
-def _find_backup_name(img_path):
-    """Generate a new, unique backup pathname."""
-    img_backup = ("%s.boom" % img_path)[1:] + "%d"
-
-    def _backup_img(backup_nr):
-        return sep + img_backup % backup_nr
-
-    def _backup_path(backup_nr):
-        return join(get_boot_path(), img_backup[1:] % backup_nr)
-
-    backup_nr = 0
-    while path_exists(_backup_path(backup_nr)):
-        if find_cache_paths(Selection(path=_backup_img(backup_nr))):
-            break
-        backup_nr += 1
-    return sep + img_backup % backup_nr
-
-
 def _cache_image(img_path, backup):
     """Cache the image found at ``img_path`` and optionally create
     a backup copy.
@@ -909,16 +891,13 @@ def _cache_image(img_path, backup):
                 return img_path
     try:
         if backup:
-            img_backup = _find_backup_name(img_path)
-            _log_debug("backing up '%s' as '%s'" % (img_path, img_backup))
-            ce = backup_path(img_path, img_backup)
-            return img_backup
+            ce = backup_path(img_path)
         else:
             ce = cache_path(img_path)
     except (OSError, ValueError) as e:
         _log_error("Could not cache path %s: %s" % (img_path, e))
         raise e
-    return img_path
+    return ce.path
 
 
 def _find_one_entry(select):

--- a/boom/command.py
+++ b/boom/command.py
@@ -880,7 +880,7 @@ I_BACKUP = "backup"
 #
 
 
-def _cache_image(img_path, backup):
+def _cache_image(img_path, backup, update=False):
     """Cache the image found at ``img_path`` and optionally create
     a backup copy.
     """
@@ -891,9 +891,9 @@ def _cache_image(img_path, backup):
                 return img_path
     try:
         if backup:
-            ce = backup_path(img_path)
+            ce = backup_path(img_path, update=update)
         else:
-            ce = cache_path(img_path)
+            ce = cache_path(img_path, update=update)
     except (OSError, ValueError) as e:
         _log_error("Could not cache path %s" % img_path)
         raise e
@@ -932,6 +932,7 @@ def create_entry(
     expand=False,
     allow_no_dev=False,
     images=I_NONE,
+    update=False,
     no_fstab=False,
     mounts=None,
     swaps=None,
@@ -1032,8 +1033,8 @@ def create_entry(
     )
 
     if images in (I_BACKUP, I_CACHE):
-        be.initrd = _cache_image(be.initrd, images == I_BACKUP)
-        be.linux = _cache_image(be.linux, images == I_BACKUP)
+        be.initrd = _cache_image(be.initrd, images == I_BACKUP, update=update)
+        be.linux = _cache_image(be.linux, images == I_BACKUP, update=update)
 
     if find_entries(Selection(boot_id=be.boot_id)):
         raise ValueError("Entry already exists (boot_id=%s)." % be.disp_boot_id)
@@ -2596,6 +2597,7 @@ def _create_cmd(cmd_args, select, opts, identifier):
             expand=cmd_args.expand_variables,
             allow_no_dev=no_dev,
             images=images,
+            update=cmd_args.update,
             no_fstab=cmd_args.no_fstab,
             mounts=cmd_args.mount,
             swaps=cmd_args.swap,
@@ -4115,6 +4117,11 @@ def main(args):
         help="A Boom OsProfile uname pattern",
         metavar="PATTERN",
         type=str,
+    )
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="Update cached images when creating backups",
     )
     parser.add_argument("-V", "--verbose", help="Enable verbose output", action="count")
     parser.add_argument(

--- a/man/man8/boom.8
+++ b/man/man8/boom.8
@@ -90,6 +90,7 @@ Boom \(em linux boot manager
 .  RB [ --del-opts
 .  IR opts ]
 .  RB [ --backup ]
+.  RB [ --update ]
 .  RB [ --no-fstab ]
 .  RB [ --mount
 .  IR mount ]
@@ -144,6 +145,7 @@ Boom \(em linux boot manager
 .  RB [ --del-opts
 .  IR opts ]
 .  RB [ --backup ]
+.  RB [ --update ]
 .  RB [ --no-fstab ]
 .  RB [ --mount
 .  IR mount ]
@@ -925,6 +927,12 @@ The title for a new boot entry.
 An uname pattern to match for an operating system profile.
 .
 .HP
+.BR --update
+.br
+When used with \fB--backup\fP update the backup image to the current
+version found in the boot directory.
+.
+.HP
 .BR -V | --verbose
 .br
 Increase verbosity level. Specify multiple times, or set additional
@@ -1021,7 +1029,8 @@ If \fB--backup\fP is given a backup is made of the boot images (vmlinuz
 and initramfs) used by the boot entry and the new entry will use the
 backup paths instead of the original image paths. By default if an
 existing backup image is present it will be re-used instead of using the
-latest matching image found in the boot directory.
+latest matching image found in the boot directory. This behaviour can be
+overridden by using the \fB--update\fP option.
 
 The newly created entry and its boot identifier are printed to the
 terminal on success:
@@ -1074,7 +1083,9 @@ If \fB--backup\fP is given a backup is made of the boot images (vmlinuz
 and initramfs) used by the boot entry and the new entry will use the
 backup paths instead of the original image paths. By default if an
 existing backup image is present it will be re-used instead of using the
-latest matching image found in the boot directory.
+latest matching image found in the boot directory. This behaviour can be
+overridden by using the \fB--update\fP option.
+
 
 On success the new entry and its boot identifier are printed to the
 terminal.

--- a/man/man8/boom.8
+++ b/man/man8/boom.8
@@ -89,6 +89,7 @@ Boom \(em linux boot manager
 .  IR opts ]
 .  RB [ --del-opts
 .  IR opts ]
+.  RB [ --backup ]
 .  RB [ --no-fstab ]
 .  RB [ --mount
 .  IR mount ]
@@ -142,6 +143,7 @@ Boom \(em linux boot manager
 .  IR opts ]
 .  RB [ --del-opts
 .  IR opts ]
+.  RB [ --backup ]
 .  RB [ --no-fstab ]
 .  RB [ --mount
 .  IR mount ]
@@ -701,6 +703,11 @@ Specify additional boot options for this entry.
 Specify boot options to exclude from this entry.
 .
 .HP
+.BR --backup
+.br
+Back up boot images used for this entry.
+.
+.HP
 .BR -b | --boot-id | --bootid
 .IR boot_id
 .br
@@ -1010,6 +1017,12 @@ templates may be specified with \fB--add-opts\fP. Options may also be
 removed from the entry using \fB--del-opts\fP (for example to disable
 graphical boot or the "quiet" flag for a particular entry).
 
+If \fB--backup\fP is given a backup is made of the boot images (vmlinuz
+and initramfs) used by the boot entry and the new entry will use the
+backup paths instead of the original image paths. By default if an
+existing backup image is present it will be re-used instead of using the
+latest matching image found in the boot directory.
+
 The newly created entry and its boot identifier are printed to the
 terminal on success:
 .br
@@ -1056,6 +1069,12 @@ Clone an existing boot entry and modify its configuration.
 The entry to clone must be specified by its \fBboot identifier\fP.
 Any remaining command line arguments are taken to be modifications
 to the original entry.
+
+If \fB--backup\fP is given a backup is made of the boot images (vmlinuz
+and initramfs) used by the boot entry and the new entry will use the
+backup paths instead of the original image paths. By default if an
+existing backup image is present it will be re-used instead of using the
+latest matching image found in the boot directory.
 
 On success the new entry and its boot identifier are printed to the
 terminal.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -124,6 +124,7 @@ class MockArgs(object):
     sort = ""
     swap = ""
     title = ""
+    update = False
     type = ""
     uname_pattern = ""
     verbose = 0

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -335,7 +335,7 @@ class CacheTests(unittest.TestCase):
         img_path = join("/", img_name)
         backup_img = img_path + ".boom0"
 
-        backup_path(img_path, backup_img)
+        backup_path(img_path)
 
         # Assert backup is in cache
         ces = find_cache_paths(Selection(path=backup_img))


### PR DESCRIPTION
If an image has already been backed up by boom and is subsequently modified attempting to create a new boot entry using the same image and --backup fails with:

```
# boom create --title BackupTest2 --backup --root-lv fedora/root
ERROR - Could not cache path /initramfs-6.8.9-300.fc40.x86_64.img: Restore failed: CacheEntry state is not MISSING or RESTORED
Restore failed: CacheEntry state is not MISSING or RESTORED
```

This can happen when package scripts regenerate the initramfs image between the time the first and second boot entries are created.

The status of the cached image is reported as CACHED rather than RESTORED because the hash of the image in /boot does not match the expected cached value:

```
# boom cache list
Path                                       ImageID Timestamp  State
/initramfs-6.8.9-300.fc40.x86_64.img.boom0 bcc364b 1723557576 CACHED
/vmlinuz-6.8.9-300.fc40.x86_64.boom0       10c480b 1714608000 RESTORED
```

This happens because the logic to generate a path name for the backup image fails to ensure uniqueness in the case that the image hash has changed. The original version remains in /boot and prevents the updated image from being restored.

Fix this my moving the generation of the unique path from boom.command into boom.cache where we can whether the image is already cached, or if it is a modified/updated version of the same path name.