### PR TITLE
Update boom-boot.spec

### DIFF
--- a/boom-boot.spec
+++ b/boom-boot.spec
@@ -22,7 +22,6 @@ BuildRequires:	python3-dbus
 BuildRequires:	python3-sphinx
 %endif
 BuildRequires: make
-BuildRequires: systemd-rpm-macros
 
 Requires: python3-boom = %{version}-%{release}
 Requires: %{name}-conf = %{version}-%{release}

--- a/boom-boot.spec
+++ b/boom-boot.spec
@@ -8,7 +8,7 @@ Summary:	%{summary}
 
 License:	GPL-2.0-only
 URL:		https://github.com/snapshotmanager/boom-boot
-Source0:	%{url}/archive/%{version}/boom-%{version}.tar.gz
+Source0:	%{url}/archive/%{version}/%{name}-%{version}.tar.gz
 
 BuildArch:	noarch
 
@@ -81,7 +81,7 @@ include this support in both Red Hat Enterprise Linux 7 and Fedora).
 This package provides configuration files for boom.
 
 %prep
-%autosetup -p1 -n boom-%{version}
+%autosetup -p1 -n %{name}-%{version}
 
 %build
 %if 0%{?sphinx_docs}

--- a/boom-boot.spec
+++ b/boom-boot.spec
@@ -3,7 +3,7 @@
 
 Name:		boom-boot
 Version:	1.6.5
-Release:	1%{?dist}
+Release:	2%{?dist}
 Summary:	%{summary}
 
 License:	GPL-2.0-only
@@ -154,6 +154,10 @@ rm doc/conf.py
 
 
 %changelog
+* Fri Sep 27 2024 Bryn M. Reeves <bmr@redhat.com> - 1.6.5-2
+- dist: drop unused systemd-rpm-macros BuildRequires
+- dist: fix Source URL and autosetup invocation
+
 * Tue Sep 17 2024 Bryn M. Reeves <bmr@redhat.com> - 1.6.5-1
 - doc: add --update to boom.8
 - doc: add --backup to boom.8


### PR DESCRIPTION
Update the spec file to use the current tarball URL and name and drop the no-longer-used `BuldRequires: systemd-rpm-macros`.