### PR TITLE
boom: clean up new OsProfile if setting uname_pattern fails

### DIFF
--- a/boom/command.py
+++ b/boom/command.py
@@ -1573,7 +1573,9 @@ def _os_profile_from_file(os_release, uname_pattern, profile_data=None):
         osp.uname_pattern = _uname_heuristic(osp.os_name, osp.os_version_id)
 
     if not osp.uname_pattern:
+        osp.delete_profile()
         raise ValueError("Could not determine uname pattern for '%s'" % osp.os_name)
+
     if not osp.optional_keys:
         osp.optional_keys = _default_optional_keys(osp)
 

--- a/boom/legacy.py
+++ b/boom/legacy.py
@@ -237,7 +237,7 @@ def clear_legacy_loader(loader=BOOM_LOADER_GRUB1, cfg_path=None):
         """Helper function to clean up the temporary file and raise the
         corresponding BoomLegacyFormatError exception.
         """
-        if type(fmt_data[0]) == int:
+        if fmt_data[0] is int:
             fmt_data = ("line %d" % fmt_data[0], fmt_data[1])
 
         try:


### PR DESCRIPTION
Explicitly delete new `OsProfile` if no `uname_pattern` is supplied and `_uname_heuristic()` fails to determine one.

Resolves: #62.