### PR TITLE
boom: use lazy printf formatting when logging

### DIFF
--- a/boom/_boom.py
+++ b/boom/_boom.py
@@ -398,7 +398,7 @@ def set_boot_path(boot_path):
         raise ValueError("Path '%s' does not exist" % boot_path)
 
     __config.boot_path = boot_path
-    _log_debug("Set boot path to: %s" % boot_path)
+    _log_debug("Set boot path to: %s", boot_path)
     __config.boom_path = path_join(boot_path, DEFAULT_BOOM_DIR)
 
     # If a boom/ directory exists at the boot path, automatically set
@@ -439,7 +439,7 @@ def set_boom_path(boom_path):
             ": %s" % path_join(boom_path, "profiles")
         )
 
-    _log_debug("Set boom path to: %s" % boom_path)
+    _log_debug("Set boom path to: %s", boom_path)
     __config.boom_path = boom_path
     set_boom_config_path(__config.boom_path)
 
@@ -473,7 +473,7 @@ def set_cache_path(cache_path):
         cache_path = path_join(__config.cache_path, cache_path)
 
     __config.cache_path = cache_path
-    _log_debug("Set cache path to: %s" % cache_path)
+    _log_debug("Set cache path to: %s", cache_path)
 
 
 def get_boom_config_path():
@@ -496,7 +496,7 @@ def set_boom_config_path(path):
     if not path_exists(path):
         raise IOError(ENOENT, "File not found: '%s'" % path)
     __boom_config_path = path
-    _log_debug("set boom_config_path to '%s'" % path)
+    _log_debug("set boom_config_path to '%s'", path)
 
 
 def parse_btrfs_subvol(subvol):
@@ -818,7 +818,7 @@ class Selection(object):
             host_id=args.host_id,
         )
 
-        _log_debug("Initialised %s from arguments" % repr(s))
+        _log_debug("Initialised %s from arguments", repr(s))
         return s
 
     def __attr_has_value(self, attr):
@@ -1029,7 +1029,7 @@ def load_profiles_for_class(profile_class, profile_type, profiles_path, profile_
     :returns: None
     """
     profile_files = listdir(profiles_path)
-    _log_debug("Loading %s profiles from %s" % (profile_type, profiles_path))
+    _log_debug("Loading %s profiles from %s", profile_type, profiles_path)
     for pf in profile_files:
         if not pf.endswith(".%s" % profile_ext):
             continue
@@ -1038,7 +1038,7 @@ def load_profiles_for_class(profile_class, profile_type, profiles_path, profile_
             profile_class(profile_file=pf_path)
         except Exception as e:
             _log_warn(
-                "Failed to load %s from '%s': %s" % (profile_class.__name__, pf_path, e)
+                "Failed to load %s from '%s': %s", profile_class.__name__, pf_path, e
             )
             if get_debug_mask():
                 raise e

--- a/boom/bootloader.py
+++ b/boom/bootloader.py
@@ -294,7 +294,7 @@ def _grub2_get_env(name):
         p = Popen(grub_cmd, stdin=None, stdout=PIPE, stderr=PIPE)
         out = p.communicate()[0]
     except OSError as e:
-        _log_error("Could not obtain grub2 environment: %s" % e)
+        _log_error("Could not obtain grub2 environment: %s", e)
         return ""
 
     for line in out.decode("utf8").splitlines():
@@ -512,7 +512,7 @@ class BootParams(object):
         self.add_opts = add_opts or []
         self.del_opts = del_opts or []
 
-        _log_debug_entry("Initialised %s" % repr(self))
+        _log_debug_entry("Initialised %s", repr(self))
 
     # We have to use explicit properties for BootParam attributes since
     # we need to track modifications to the BootParams values to allow
@@ -672,9 +672,9 @@ class BootParams(object):
             return None
 
         _log_debug_entry(
-            "Matching options regex list with %d entries" % len(opts_regexes)
+            "Matching options regex list with %d entries", len(opts_regexes)
         )
-        _log_debug_entry("Options regex list: %s" % str(opts_regexes))
+        _log_debug_entry("Options regex list: %s", str(opts_regexes))
 
         for rgx_word in opts_regexes:
             (name, exp) = rgx_word
@@ -684,23 +684,25 @@ class BootParams(object):
                 if match:
                     if len(match.groups()):
                         value = match.group(1)
-                        _log_debug_entry("Matching: '%s' (%s)" % (value, name))
+                        _log_debug_entry("Matching: '%s' (%s)", value, name)
                     if name == "lvm_root_lv":
                         if not _match_root_lv(bp.root_device, value):
                             continue
                         _log_debug_entry(
-                            "Matched root_device=%s to %s=%s"
-                            % (bp.root_device, name, value)
+                            "Matched root_device=%s to %s=%s",
+                            bp.root_device,
+                            name,
+                            value,
                         )
                     matches[word] = True
                     if name:
-                        _log_debug_entry("Matched %s=%s" % (name, value))
+                        _log_debug_entry("Matched %s=%s", name, value)
                         setattr(bp, name, value)
 
             # The root_device key is handled specially since it is required
             # for a valid BootEntry.
             if name == "root_device" and not value:
-                _log_warn("No root_device for entry at %s" % be._last_path)
+                _log_warn("No root_device for entry at %s", be._last_path)
                 setattr(bp, name, "")
 
         def is_add(opt):
@@ -726,7 +728,7 @@ class BootParams(object):
             if opt not in matches.keys():
                 if opt not in be._osp.options.split():
                     if not opt_in_expansion(opt):
-                        _log_debug_entry("Found add_opt: %s" % opt)
+                        _log_debug_entry("Found add_opt: %s", opt)
                         return True
             return False
 
@@ -754,7 +756,7 @@ class BootParams(object):
             opt_name = opt.split("=")[0]
             matched_opts = [k.split("=")[0] for k in matches.keys()]
             if opt_name not in matched_opts and opt_name not in ignore_bp:
-                _log_debug_entry("Found del_opt: %s" % opt)
+                _log_debug_entry("Found del_opt: %s", opt)
                 return True
             return False
 
@@ -766,7 +768,7 @@ class BootParams(object):
         # Compile list of deleted template options
         bp.del_opts = [o for o in [r[1] for r in opts_regexes] if is_del(o)]
 
-        _log_debug_entry("Parsed %s" % repr(bp))
+        _log_debug_entry("Parsed %s", repr(bp))
 
         return bp
 
@@ -822,7 +824,7 @@ def load_entries(machine_id=None):
 
     drop_entries()
 
-    _log_debug("Loading boot entries from '%s'" % entries_path)
+    _log_debug("Loading boot entries from '%s'", entries_path)
     for entry in listdir(entries_path):
         if not entry.endswith(".conf"):
             continue
@@ -833,11 +835,11 @@ def load_entries(machine_id=None):
         try:
             _add_entry(BootEntry(entry_file=entry_path))
         except Exception as e:
-            _log_info("Could not load BootEntry '%s': %s" % (entry_path, e))
+            _log_info("Could not load BootEntry '%s': %s", entry_path, e)
             if get_debug_mask():
                 raise e
 
-    _log_debug("Loaded %d entries" % len(_entries))
+    _log_debug("Loaded %d entries", len(_entries))
 
 
 def write_entries():
@@ -851,9 +853,7 @@ def write_entries():
         try:
             be.write_entry()
         except Exception as e:
-            _log_warn(
-                "Could not write BootEntry(boot_id='%s'): %s" % (be.disp_boot_id, e)
-            )
+            _log_warn("Could not write BootEntry(boot_id='%s'): %s", be.disp_boot_id, e)
 
 
 def min_boot_id_width():
@@ -960,13 +960,13 @@ def find_entries(selection=None):
 
     selection.check_valid_selection(entry=True, params=True, profile=True)
 
-    _log_debug_entry("Finding entries for %s" % repr(selection))
+    _log_debug_entry("Finding entries for %s", repr(selection))
 
     for be in _entries:
         if select_entry(selection, be):
             matches.append(be)
 
-    _log_debug_entry("Found %d entries" % len(matches))
+    _log_debug_entry("Found %d entries", len(matches))
     return matches
 
 
@@ -1317,7 +1317,7 @@ class BootEntry(object):
             # the comment list.
             if not self._osp and osp:
                 self._osp = osp
-                _log_debug_entry("Parsed os_id='%s' from comment" % osp.disp_os_id)
+                _log_debug_entry("Parsed os_id='%s' from comment", osp.disp_os_id)
             else:
                 outlines += line + "\n"
         return outlines
@@ -1409,8 +1409,7 @@ class BootEntry(object):
             self._entry_data[BOOM_ENTRY_VERSION] = self.bp.version
         else:
             _log_debug_entry(
-                "Initialising BootParams() from "
-                "BootEntry(boot_id='%s')" % self.boot_id
+                "Initialising BootParams() from BootEntry(boot_id='%s')", self.boot_id
             )
             # Attempt to recover BootParams from entry data
             self._bp = BootParams.from_entry(self)
@@ -1490,7 +1489,7 @@ class BootEntry(object):
         comment = ""
 
         entry_basename = basename(entry_file)
-        _log_debug("Loading BootEntry from '%s'" % entry_basename)
+        _log_debug("Loading BootEntry from '%s'", entry_basename)
         self._last_path = entry_file
 
         with open(entry_file, "r") as ef:
@@ -1536,11 +1535,11 @@ class BootEntry(object):
 
         match = re.match(BOOT_ENTRIES_PATTERN, entry_basename)
         if not match or len(match.groups()) <= 1:
-            _log_info("Marking unknown boot entry as read-only: %s" % entry_basename)
+            _log_info("Marking unknown boot entry as read-only: %s", entry_basename)
             self.read_only = True
         else:
             if self.disp_boot_id != match.group(2):
-                _log_info("Entry file name does not match boot_id: %s" % entry_basename)
+                _log_info("Entry file name does not match boot_id: %s", entry_basename)
                 self.update_entry(force=True)
 
         self._unwritten = False
@@ -1932,7 +1931,7 @@ class BootEntry(object):
             self._dirty()
         if not self.__boot_id or self._unwritten:
             self.__boot_id = self.__generate_boot_id()
-            _log_debug_entry("Generated new boot_id='%s'" % self.__boot_id)
+            _log_debug_entry("Generated new boot_id='%s'", self.__boot_id)
         return self.__boot_id
 
     @property
@@ -2412,11 +2411,11 @@ class BootEntry(object):
             rename(tmp_path, entry_path)
             chmod(entry_path, BOOT_ENTRY_MODE)
         except Exception as e:
-            _log_error("Error writing entry file %s: %s" % (entry_path, e))
+            _log_error("Error writing entry file %s: %s", entry_path, e)
             try:
                 unlink(tmp_path)
             except Exception:
-                _log_error("Error unlinking temporary path %s" % tmp_path)
+                _log_error("Error unlinking temporary path %s", tmp_path)
             raise e
 
         self._last_path = entry_path
@@ -2463,7 +2462,7 @@ class BootEntry(object):
             try:
                 unlink(to_unlink)
             except Exception as e:
-                _log_error("Error unlinking entry file %s: %s" % (to_unlink, e))
+                _log_error("Error unlinking entry file %s: %s", to_unlink, e)
 
     def delete_entry(self):
         """Remove on-disk BootEntry file.
@@ -2487,7 +2486,7 @@ class BootEntry(object):
         try:
             unlink(self._entry_path)
         except Exception as e:
-            _log_error("Error removing entry file %s: %s" % (self._entry_path, e))
+            _log_error("Error removing entry file %s: %s", self._entry_path, e)
             raise
 
         if not self._unwritten:

--- a/boom/cache.py
+++ b/boom/cache.py
@@ -207,7 +207,7 @@ def load_cache(verify=True, digests=False):
 
     index_path = path_join(cache_path, _CACHE_INDEX)
 
-    _log_debug("Loading cache entries from '%s'" % index_path)
+    _log_debug("Loading cache entries from '%s'", index_path)
 
     # Get the set of known image_id values
     ids = _load_image_ids(cache_path)
@@ -228,26 +228,26 @@ def load_cache(verify=True, digests=False):
         for image_id in index[path]:
             if image_id not in ids:
                 _log_warn(
-                    "Image identifier '%s' not found in cache"
-                    " for path %s" % (image_id, path)
+                    "Image identifier '%s' not found in cache for path %s",
+                    image_id,
+                    path,
                 )
                 # mark as broken
 
     paths = cachedata["paths"]
     for path in paths.keys():
         if path not in index:
-            _log_warn("No image for path '%s' found in cache" % path)
+            _log_warn("No image for path '%s' found in cache", path)
             # mark as broken
 
     images = cachedata["images"]
     for image_id in images.keys():
         if image_id not in ids:
-            _log_warn("Found unknown image_id '%s'" % image_id)
+            _log_warn("Found unknown image_id '%s'", image_id)
             # clean up?
 
     _log_debug(
-        "Loaded %d cache paths and %d images"
-        % (len(paths), len(sum(index.values(), [])))
+        "Loaded %d cache paths and %d images", len(paths), len(sum(index.values(), []))
     )
 
     _index = index
@@ -284,7 +284,7 @@ def _insert(boot_path, cache_path):
         # FIXME: implement hard link support with fall-back to copy.
         _insert_copy(boot_path, cache_path)
     except Exception as e:
-        _log_error("Error copying '%s' to cache: %s" % (boot_path, e))
+        _log_error("Error copying '%s' to cache: %s", boot_path, e)
         raise e
 
 
@@ -314,7 +314,7 @@ def _remove(cache_path):
     try:
         _remove_copy(cache_path)
     except Exception as e:
-        _log_error("Error removing cache image '%s': %s" % (cache_path, e))
+        _log_error("Error removing cache image '%s': %s", cache_path, e)
         raise e
 
 
@@ -369,7 +369,7 @@ def _cache_path(img_path, update=True, backup=False):
     st = stat(boot_path)
 
     if not S_ISREG(st[ST_MODE]):
-        _log_error("Image at path '%s' is not a regular file." % img_path)
+        _log_error("Image at path '%s' is not a regular file.", img_path)
         raise ValueError("'%s' is not a regular file" % img_path)
 
     img_id = _image_id_from_path(boot_path)
@@ -386,15 +386,14 @@ def _cache_path(img_path, update=True, backup=False):
             return find_cache_images(Selection(img_id=img_id))[0]
 
         img_path = _find_backup_name(img_path)
-        _log_debug_cache("Backing up path '%s' as '%s'" % (boot_path, img_path))
+        _log_debug_cache("Backing up path '%s' as '%s'", boot_path, img_path)
 
     if img_path in _paths and img_id in _index[img_path]:
         _log_info(
-            "Image with img_id=%s already cached for path '%s'"
-            % (img_id[0:6], img_path)
+            "Image with img_id=%s already cached for path '%s'", img_id[0:6], img_path
         )
         return this_entry()
-    _log_info("Adding new image with img_id=%s for path '%s'" % (img_id[0:6], img_path))
+    _log_info("Adding new image with img_id=%s for path '%s'", img_id[0:6], img_path)
 
     path_mode = st[ST_MODE]
     path_uid = st[ST_UID]
@@ -419,7 +418,7 @@ def cache_path(img_path, update=False):
                      the configured /boot directory.
     :returns: None
     """
-    _log_debug_cache("Caching path '%s'" % img_path)
+    _log_debug_cache("Caching path '%s'", img_path)
     return _cache_path(img_path, update=update)
 
 
@@ -458,13 +457,11 @@ def uncache_path(img_path, force=False):
     count = ce.count
 
     if count and not force:
-        _log_info(
-            "Retaining cache path '%s' used by %d boot entries" % (img_path, count)
-        )
+        _log_info("Retaining cache path '%s' used by %d boot entries", img_path, count)
         return
 
     if count:
-        _log_warn("Uncaching path '%s' used by %d boot entries" % (img_path, count))
+        _log_warn("Uncaching path '%s' used by %d boot entries", img_path, count)
 
     # Remove entry from the path index and metadata
     images = _index.pop(img_path)
@@ -497,7 +494,7 @@ def clean_cache():
             nr_unused += 1
             ce.uncache()
     if nr_unused:
-        _log_info("Removed %d unused cache entries" % nr_unused)
+        _log_info("Removed %d unused cache entries", nr_unused)
 
 
 #: Boom restored dot file pattern
@@ -731,7 +728,7 @@ def _find_cache_entries(selection=None, images=False):
 
     selection.check_valid_selection(cache=True)
 
-    _log_debug_cache("Finding cache entries for %s" % repr(selection))
+    _log_debug_cache("Finding cache entries for %s", repr(selection))
 
     for path in _index:
 
@@ -771,7 +768,7 @@ def find_cache_paths(selection=None):
     :returns: A list of matching ``CacheEntry`` objects.
     """
     matches = _find_cache_entries(selection=selection, images=False)
-    _log_debug_cache("Found %d cached paths" % len(matches))
+    _log_debug_cache("Found %d cached paths", len(matches))
     return matches
 
 
@@ -787,7 +784,7 @@ def find_cache_images(selection=None):
     :returns: A list of matching ``CacheEntry`` objects.
     """
     matches = _find_cache_entries(selection=selection, images=True)
-    _log_debug_cache("Found %d cached images" % len(matches))
+    _log_debug_cache("Found %d cached images", len(matches))
     return matches
 
 

--- a/boom/command.py
+++ b/boom/command.py
@@ -757,7 +757,12 @@ def __write_legacy():
 
 
 def _do_print_type(
-    report_fields, selected, output_fields=None, opts=None, sort_keys=None, title=None,
+    report_fields,
+    selected,
+    output_fields=None,
+    opts=None,
+    sort_keys=None,
+    title=None,
 ):
     """Print an object type report (entry, osprofile, hostprofile).
 
@@ -780,7 +785,12 @@ def _do_print_type(
     opts = opts if opts is not None else ReportOpts()
 
     br = Report(
-        _report_obj_types, report_fields, output_fields, opts, sort_keys, title,
+        _report_obj_types,
+        report_fields,
+        output_fields,
+        opts,
+        sort_keys,
+        title,
     )
 
     for obj in selected:

--- a/boom/command.py
+++ b/boom/command.py
@@ -707,7 +707,7 @@ def _get_machine_id():
         try:
             machine_id = f.read().strip()
         except Exception as e:
-            _log_error("Could not read machine-id from '%s': %s" % (path, e))
+            _log_error("Could not read machine-id from '%s': %s", path, e)
             machine_id = None
     return machine_id
 
@@ -837,10 +837,10 @@ def _merge_add_del_opts(bp, add_opts, del_opts):
                     all_opts.append(opt)
         return [o for o in all_opts if o not in r_opts]
 
-    _log_debug_cmd("Add opts: %s" % add_opts)
-    _log_debug_cmd("Del opts: %s" % del_opts)
-    _log_debug_cmd("Original add_opts: %s" % bp.add_opts)
-    _log_debug_cmd("Original del_opts: %s" % bp.del_opts)
+    _log_debug_cmd("Add opts: %s", add_opts)
+    _log_debug_cmd("Del opts: %s", del_opts)
+    _log_debug_cmd("Original add_opts: %s", bp.add_opts)
+    _log_debug_cmd("Original del_opts: %s", bp.del_opts)
 
     r_del_opts = []
     r_add_opts = []
@@ -867,8 +867,8 @@ def _merge_add_del_opts(bp, add_opts, del_opts):
     add_opts = _merge_opts(bp.add_opts, add_opts, r_add_opts)
     del_opts = _merge_opts(bp.del_opts, del_opts, r_del_opts)
 
-    _log_debug_cmd("Effective add options: %s" % add_opts)
-    _log_debug_cmd("Effective del options: %s" % del_opts)
+    _log_debug_cmd("Effective add options: %s", add_opts)
+    _log_debug_cmd("Effective del options: %s", del_opts)
 
     return (add_opts, del_opts)
 
@@ -905,7 +905,7 @@ def _cache_image(img_path, backup, update=False):
         else:
             ce = cache_path(img_path, update=update)
     except (OSError, ValueError) as e:
-        _log_error("Could not cache path %s" % img_path)
+        _log_error("Could not cache path %s", img_path)
         raise e
     return ce.path
 
@@ -1020,8 +1020,8 @@ def create_entry(
         swap_units = parse_swap_units(swaps)
         add_opts.extend(swap_units)
 
-    _log_debug_cmd("Effective add options: %s" % add_opts)
-    _log_debug_cmd("Effective del options: %s" % del_opts)
+    _log_debug_cmd("Effective add options: %s", add_opts)
+    _log_debug_cmd("Effective del options: %s", del_opts)
 
     bp = BootParams(
         version,
@@ -1176,7 +1176,7 @@ def clone_entry(
 
     be = _find_one_entry(selection)
 
-    _log_debug("Cloning entry with boot_id='%s'" % be.disp_boot_id)
+    _log_debug("Cloning entry with boot_id='%s'", be.disp_boot_id)
 
     title = title if title else be.title
     version = version if version else be.version
@@ -1324,7 +1324,7 @@ def edit_entry(
 
     be = _find_one_entry(selection)
 
-    _log_debug("Editing entry with boot_id='%s'" % be.disp_boot_id)
+    _log_debug("Editing entry with boot_id='%s'", be.disp_boot_id)
 
     # Use a matching HostProfile is one exists, or the command line
     # OsProfile argument if set.
@@ -1468,7 +1468,7 @@ def _find_profile(cmd_args, version, machine_id, command, optional=True):
     osp = osps[0] if osps else None
 
     if osp:
-        _log_debug("Found OsProfile: %s" % osp.os_id)
+        _log_debug("Found OsProfile: %s", osp.os_id)
 
     # Attempt to match a host profile to the running host
     label = cmd_args.label or ""
@@ -1482,19 +1482,20 @@ def _find_profile(cmd_args, version, machine_id, command, optional=True):
         _log_error("Ambiguous host profile selection")
         return None
     elif len(hps) == 1:
-        _log_debug("Found HostProfile: %s" % hps[0].host_id)
+        _log_debug("Found HostProfile: %s", hps[0].host_id)
         if (hp and osp) and not osp.os_id.startswith(hp.os_id):
             _log_error(
                 "Active host profile (host_id=%s, os_id=%s) "
-                "conflicts with --profile=%s"
-                % (hp.disp_host_id, hp.disp_os_id, osp.disp_os_id)
+                "conflicts with --profile=%s",
+                hp.disp_host_id,
+                hp.disp_os_id,
+                osp.disp_os_id,
             )
             return None
     elif not osp and not hps:
         if not optional:
             _log_error(
-                "%s requires --profile or a matching OsProfile "
-                "or HostProfile" % command
+                "%s requires --profile or a matching OsProfile or HostProfile", command
             )
         return None
 
@@ -4191,33 +4192,33 @@ def main(args):
         try:
             bc = load_boom_config()
         except ValueError as e:
-            _log_error("Could not load boom configuration: %s" % e)
+            _log_error("Could not load boom configuration: %s", e)
 
         if not path_exists(get_boom_path()):
-            _log_error("Configuration directory '%s' not found." % get_boom_path())
+            _log_error("Configuration directory '%s' not found.", get_boom_path())
             print("Run 'boom config create' to generate default configuration")
             return 1
 
         if not path_exists(get_boom_config_path()):
-            _log_error("Configuration file '%s' not found." % get_boom_config_path())
+            _log_error("Configuration file '%s' not found.", get_boom_config_path())
             return 1
 
         if not path_exists(boom_profiles_path()):
             _log_error(
-                "OS profile configuration path '%s' not found." % boom_profiles_path()
+                "OS profile configuration path '%s' not found.", boom_profiles_path()
             )
             return 1
 
         if not path_exists(boom_host_profiles_path()):
             _log_error(
-                "Host profile configuration path '%s' not found."
-                % boom_host_profiles_path()
+                "Host profile configuration path '%s' not found.",
+                boom_host_profiles_path(),
             )
             return 1
 
         if not path_exists(boom_entries_path()):
             _log_error(
-                "Boot loader entries directory '%s' not found." % boom_entries_path()
+                "Boot loader entries directory '%s' not found.", boom_entries_path()
             )
             return 1
     else:
@@ -4277,13 +4278,13 @@ def main(args):
         try:
             status = command[1](cmd_args, select, opts, identifier)
         except Exception as e:
-            _log_error("Command failed: %s" % e)
+            _log_error("Command failed: %s", e)
 
     if bc.cache_enable and bc.cache_auto_clean:
         try:
             clean_cache()
         except Exception as e:
-            _log_error("Could not clean boot image cache: %s" % e)
+            _log_error("Could not clean boot image cache: %s", e)
 
     shutdown_logging()
     return status

--- a/boom/config.py
+++ b/boom/config.py
@@ -81,12 +81,12 @@ def _read_boom_config(path=None):
     :rtype: BoomConfig
     """
     path = path or get_boom_config_path()
-    _log_debug("reading boom configuration from '%s'" % path)
+    _log_debug("reading boom configuration from '%s'", path)
     cfg = ConfigParser()
     try:
         cfg.read(path)
     except ParsingError as e:
-        _log_error("Failed to parse configuration file '%s': %s" % (path, e))
+        _log_error("Failed to parse configuration file '%s': %s", path, e)
 
     bc = BoomConfig()
 
@@ -127,7 +127,7 @@ def _read_boom_config(path=None):
             _log_debug("Found cache.cache_path")
             bc.cache_path = cfg.get(_CFG_SECT_CACHE, _CFG_CACHE_PATH)
 
-    _log_debug("read configuration: %s" % repr(bc))
+    _log_debug("read configuration: %s", repr(bc))
     bc._cfg = cfg
     return bc
 
@@ -211,11 +211,11 @@ def write_boom_config(config=None, path=None):
         rename(tmp_path, path)
         chmod(path, BOOT_CONFIG_MODE)
     except Exception as e:
-        _log_error("Error writing configuration file %s: %s" % (path, e))
+        _log_error("Error writing configuration file %s: %s", path, e)
         try:
             unlink(tmp_path)
         except Exception:
-            _log_error("Error unlinking temporary path %s" % tmp_path)
+            _log_error("Error unlinking temporary path %s", tmp_path)
         raise e
 
 

--- a/boom/hostprofile.py
+++ b/boom/hostprofile.py
@@ -215,7 +215,7 @@ def load_host_profiles():
     load_profiles_for_class(HostProfile, "Host", profiles_path, "host")
 
     _host_profiles_loaded = True
-    _log_debug("Loaded %d host profiles" % len(_host_profiles))
+    _log_debug("Loaded %d host profiles", len(_host_profiles))
 
 
 def write_host_profiles(force=False):
@@ -227,14 +227,15 @@ def write_host_profiles(force=False):
     :rtype: None
     """
     global _host_profiles
-    _log_debug("Writing host profiles to %s" % boom_host_profiles_path())
+    _log_debug("Writing host profiles to %s", boom_host_profiles_path())
     for hp in _host_profiles:
         try:
             hp.write_profile(force)
         except Exception as e:
             _log_warn(
-                "Failed to write HostProfile(machine_id='%s'): %s"
-                % (hp.disp_machine_id, e)
+                "Failed to write HostProfile(machine_id='%s'): %s",
+                hp.disp_machine_id,
+                e,
             )
 
 
@@ -344,11 +345,11 @@ def find_host_profiles(selection=None, match_fn=select_host_profile):
 
     matches = []
 
-    _log_debug_profile("Finding host profiles for %s" % repr(selection))
+    _log_debug_profile("Finding host profiles for %s", repr(selection))
     for hp in _host_profiles:
         if match_fn(selection, hp):
             matches.append(hp)
-    _log_debug_profile("Found %d host profiles" % len(matches))
+    _log_debug_profile("Found %d host profiles", len(matches))
     matches.sort(key=lambda h: h.host_name)
 
     return matches
@@ -393,8 +394,10 @@ def match_host_profile(entry):
 
     _log_debug(
         "Attempting to match profile for BootEntry(title='%s', "
-        "version='%s') with machine_id='%s'"
-        % (entry.title, entry.version, entry.machine_id)
+        "version='%s') with machine_id='%s'",
+        entry.title,
+        entry.version,
+        entry.machine_id,
     )
 
     # Attempt to match by uname pattern
@@ -402,8 +405,11 @@ def match_host_profile(entry):
         if hp.machine_id == entry.machine_id:
             _log_debug(
                 "Matched BootEntry(version='%s', boot_id='%s') "
-                "to HostProfile(name='%s', machine_id='%s')"
-                % (entry.version, entry.disp_boot_id, hp.host_name, hp.machine_id)
+                "to HostProfile(name='%s', machine_id='%s')",
+                entry.version,
+                entry.disp_boot_id,
+                hp.host_name,
+                hp.machine_id,
             )
             return hp
 

--- a/boom/legacy.py
+++ b/boom/legacy.py
@@ -75,7 +75,7 @@ def _get_grub1_device(force=False):
     find_rgx = r" \(hd\d+,\d+\)"
 
     try:
-        _log_debug("Calling grub1 shell with '%s'" % find_cmd)
+        _log_debug("Calling grub1 shell with '%s'", find_cmd)
         p = Popen(grub_cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
         out = p.communicate(input=bytes(find_cmd.encode("utf8")))
     except OSError:
@@ -84,7 +84,7 @@ def _get_grub1_device(force=False):
     for line in out[0].decode("utf8").splitlines():
         if re.match(find_rgx, line):
             __grub1_device = line.lstrip().rstrip()
-            _log_debug("Set grub1 device to '%s'" % __grub1_device)
+            _log_debug("Set grub1 device to '%s'", __grub1_device)
             return __grub1_device
 
 
@@ -149,9 +149,7 @@ def write_legacy_loader(selection=None, loader=BOOM_LOADER_GRUB1, cfg_path=None)
     cfg_dir = dirname(path)
 
     if not exists(cfg_dir):
-        _log_error(
-            "Cannot write %s configuration: '%s' does not exist'" % (name, cfg_dir)
-        )
+        _log_error("Cannot write %s configuration: '%s' does not exist'", name, cfg_dir)
         return
 
     begin_tag = BOOM_LEGACY_BEGIN_FMT % name
@@ -182,11 +180,11 @@ def write_legacy_loader(selection=None, loader=BOOM_LOADER_GRUB1, cfg_path=None)
                 tmp_f.write(str(dbe) + "\n")
             tmp_f.write(end_tag + "\n")
     except BoomLegacyFormatError as e:
-        _log_error("Error formatting %s configuration: %s" % (name, e))
+        _log_error("Error formatting %s configuration: %s", name, e)
         try:
             unlink(tmp_path)
         except OSError:
-            _log_error("Error unlinking temporary file '%s'" % tmp_path)
+            _log_error("Error unlinking temporary file '%s'", tmp_path)
         return
 
     try:
@@ -194,11 +192,11 @@ def write_legacy_loader(selection=None, loader=BOOM_LOADER_GRUB1, cfg_path=None)
         rename(tmp_path, path)
         chmod(path, BOOT_ENTRY_MODE)
     except Exception as e:
-        _log_error("Error writing legacy configuration file %s: %s" % (path, e))
+        _log_error("Error writing legacy configuration file %s: %s", path, e)
         try:
             unlink(tmp_path)
         except Exception:
-            _log_error("Error unlinking temporary path %s" % tmp_path)
+            _log_error("Error unlinking temporary path %s", tmp_path)
         raise e
 
 
@@ -243,7 +241,7 @@ def clear_legacy_loader(loader=BOOM_LOADER_GRUB1, cfg_path=None):
         try:
             unlink(tmp_path)
         except OSError as e:
-            _log_error("Could not unlink '%s': %s" % (tmp_path, e))
+            _log_error("Could not unlink '%s': %s", tmp_path, e)
         raise BoomLegacyFormatError(err % fmt_data)
 
     (name, decorator, path) = find_legacy_loader(loader, cfg_path)
@@ -254,9 +252,7 @@ def clear_legacy_loader(loader=BOOM_LOADER_GRUB1, cfg_path=None):
     cfg_dir = dirname(path)
 
     if not exists(cfg_dir):
-        _log_error(
-            "Cannot clear %s configuration: '%s' does not exist'" % (name, cfg_dir)
-        )
+        _log_error("Cannot clear %s configuration: '%s' does not exist'", name, cfg_dir)
         return
 
     begin_tag = BOOM_LEGACY_BEGIN_FMT % name
@@ -303,7 +299,7 @@ def clear_legacy_loader(loader=BOOM_LOADER_GRUB1, cfg_path=None):
                         tmp_f.write(line)
                     line_nr += 1
     except BoomLegacyFormatError as e:
-        _log_error("Error parsing %s configuration: %s" % (name, e))
+        _log_error("Error parsing %s configuration: %s", name, e)
         found_boom = False
 
     if in_boom_cfg and not found_boom:
@@ -314,7 +310,7 @@ def clear_legacy_loader(loader=BOOM_LOADER_GRUB1, cfg_path=None):
         try:
             unlink(tmp_path)
         except OSError as e:
-            _log_error("Could not unlink '%s': %s" % (tmp_path, e))
+            _log_error("Could not unlink '%s': %s", tmp_path, e)
         return
 
     try:
@@ -322,11 +318,11 @@ def clear_legacy_loader(loader=BOOM_LOADER_GRUB1, cfg_path=None):
         rename(tmp_path, path)
         chmod(path, BOOT_ENTRY_MODE)
     except Exception as e:
-        _log_error("Error writing legacy configuration file %s: %s" % (path, e))
+        _log_error("Error writing legacy configuration file %s: %s", path, e)
         try:
             unlink(tmp_path)
         except Exception:
-            _log_error("Error unlinking temporary path %s" % tmp_path)
+            _log_error("Error unlinking temporary path %s", tmp_path)
         raise e
 
 

--- a/boom/mounts.py
+++ b/boom/mounts.py
@@ -47,7 +47,7 @@ _blkid = "blkid"
 def _detect_fstype(dev):
     """Detect the file system type corresponding to device ``dev``."""
     p = run([_blkid, dev], stdin=DEVNULL, stdout=PIPE, stderr=PIPE, check=True)
-    _log_info("parsing mount blkid out: %s" % p.stdout)
+    _log_info("parsing mount blkid out: %s", p.stdout)
     for tag in p.stdout.decode("utf8").split():
         if "=" in tag:
             if tag.startswith("TYPE="):
@@ -63,7 +63,7 @@ def _parse_mount_unit(mount):
     :param mount: The boom command line mount specification.
     :returns: A string in systemd mount unit format.
     """
-    _log_info("parsing mount unit: %s" % mount)
+    _log_info("parsing mount unit: %s", mount)
     parts = mount.split(":")
     if len(parts) < 2:
         raise BoomMountError("Invalid mount specification: '%s'" % mount)

--- a/boom/osprofile.py
+++ b/boom/osprofile.py
@@ -238,7 +238,7 @@ def drop_profiles():
     )
     _profiles_by_id[_null_profile.os_id] = _null_profile
     if nr_profiles:
-        _log_info("Dropped %d profiles" % nr_profiles)
+        _log_info("Dropped %d profiles", nr_profiles)
     _profiles_loaded = False
 
 
@@ -259,7 +259,7 @@ def load_profiles():
     global _profiles_loaded
     drop_profiles()
     load_profiles_for_class(OsProfile, "Os", boom_profiles_path(), "profile")
-    _log_debug("Loaded %d profiles" % (len(_profiles) - 1))
+    _log_debug("Loaded %d profiles", len(_profiles) - 1)
     _profiles_loaded = True
 
 
@@ -272,14 +272,14 @@ def write_profiles(force=False):
     :rtype: None
     """
     global _profiles
-    _log_debug("Writing profiles to %s" % boom_profiles_path())
+    _log_debug("Writing profiles to %s", boom_profiles_path())
     for osp in _profiles:
         if _is_null_profile(osp):
             continue
         try:
             osp.write_profile(force)
         except Exception as e:
-            _log_warn("Failed to write OsProfile(os_id='%s'): %s" % (osp.disp_os_id, e))
+            _log_warn("Failed to write OsProfile(os_id='%s'): %s", osp.disp_os_id, e)
 
 
 def min_os_id_width():
@@ -366,11 +366,11 @@ def find_profiles(selection=None, match_fn=select_profile):
 
     matches = []
 
-    _log_debug_profile("Finding profiles for %s" % repr(selection))
+    _log_debug_profile("Finding profiles for %s", repr(selection))
     for osp in _profiles:
         if match_fn(selection, osp):
             matches.append(osp)
-    _log_debug_profile("Found %d profiles" % len(matches))
+    _log_debug_profile("Found %d profiles", len(matches))
     matches.sort(key=lambda o: (o.os_name, o.os_version))
 
     return matches
@@ -415,7 +415,9 @@ def match_os_profile(entry):
     # matched to the entry.
     _log_debug(
         "Attempting to match profile for BootEntry(title='%s', "
-        "version='%s') with unknown os_id" % (entry.title, entry.version)
+        "version='%s') with unknown os_id",
+        entry.title,
+        entry.version,
     )
 
     # Attempt to match by uname pattern
@@ -425,8 +427,11 @@ def match_os_profile(entry):
         if osp.match_uname_version(entry.version):
             _log_debug(
                 "Matched BootEntry(version='%s', boot_id='%s') "
-                "to OsProfile(name='%s', os_id='%s')"
-                % (entry.version, entry.disp_boot_id, osp.os_name, osp.disp_os_id)
+                "to OsProfile(name='%s', os_id='%s')",
+                entry.version,
+                entry.disp_boot_id,
+                osp.os_name,
+                osp.disp_os_id,
             )
             return osp
 
@@ -437,12 +442,15 @@ def match_os_profile(entry):
         if osp.match_options(entry):
             _log_debug(
                 "Matched BootEntry(version='%s', boot_id='%s') "
-                "to OsProfile(name='%s', os_id='%s')"
-                % (entry.version, entry.disp_boot_id, osp.os_name, osp.disp_os_id)
+                "to OsProfile(name='%s', os_id='%s')",
+                entry.version,
+                entry.disp_boot_id,
+                osp.os_name,
+                osp.disp_os_id,
             )
             return osp
 
-    _log_debug_profile("No matching profile found for boot_id=%s" % entry.boot_id)
+    _log_debug_profile("No matching profile found for boot_id=%s", entry.boot_id)
 
     # Assign the Null profile to this BootEntry: we cannot determine a
     # valid OsProfile to associate with it, so it cannot be modified or
@@ -676,7 +684,7 @@ class BoomProfile(object):
         comment = ""
         ptype = self.__class__.__name__
 
-        _log_debug("Loading %s from '%s'" % (ptype, basename(profile_file)))
+        _log_debug("Loading %s from '%s'", ptype, basename(profile_file))
         with open(profile_file, "r") as pf:
             for line in pf:
                 if blank_or_comment(line):
@@ -728,7 +736,7 @@ class BoomProfile(object):
         :rtype: bool
         """
         _log_debug_profile(
-            "Matching uname pattern '%s' to '%s'" % (self.uname_pattern, version)
+            "Matching uname pattern '%s' to '%s'", self.uname_pattern, version
         )
         if self.uname_pattern and version:
             if re.search(self.uname_pattern, version):
@@ -757,7 +765,7 @@ class BoomProfile(object):
 
         opts_regex_words = self.make_format_regexes(self.options)
         _log_debug_profile(
-            "Matching options regex list with %d entries" % len(opts_regex_words)
+            "Matching options regex list with %d entries", len(opts_regex_words)
         )
 
         format_opts = []
@@ -808,7 +816,7 @@ class BoomProfile(object):
         if not fmt:
             return regex_words
 
-        _log_debug_profile("Making format regex list for '%s'" % fmt)
+        _log_debug_profile("Making format regex list for '%s'", fmt)
 
         # Keys captured by single regex
         key_regex = {
@@ -1163,7 +1171,7 @@ class BoomProfile(object):
         profile_path = self._profile_path()
 
         _log_debug(
-            "Writing %s(id='%s') to '%s'" % (ptype, profile_id, basename(profile_path))
+            "Writing %s(id='%s') to '%s'", ptype, profile_id, basename(profile_path)
         )
 
         # List of key names for this profile type
@@ -1181,14 +1189,14 @@ class BoomProfile(object):
             rename(tmp_path, profile_path)
             chmod(profile_path, mode)
         except Exception as e:
-            _log_error("Error writing profile file '%s': %s" % (profile_path, e))
+            _log_error("Error writing profile file '%s': %s", profile_path, e)
             try:
                 unlink(tmp_path)
             except Exception:
-                _log_error("Error unlinking temporary path %s" % tmp_path)
+                _log_error("Error unlinking temporary path %s", tmp_path)
             raise e
 
-        _log_debug("Wrote %s (id=%s)'" % (ptype, profile_id))
+        _log_debug("Wrote %s (id=%s)'", ptype, profile_id)
 
     def write_profile(self, force=False):
         """Write out profile data to disk.
@@ -1227,17 +1235,16 @@ class BoomProfile(object):
         profile_path = self._profile_path()
 
         _log_debug(
-            "Deleting %s(id='%s') from '%s'"
-            % (ptype, profile_id, basename(profile_path))
+            "Deleting %s(id='%s') from '%s'", ptype, profile_id, basename(profile_path)
         )
 
         if not path_exists(profile_path):
             return
         try:
             unlink(profile_path)
-            _log_debug("Deleted %s(id='%s')" % (ptype, profile_id))
+            _log_debug("Deleted %s(id='%s')", ptype, profile_id)
         except Exception as e:
-            _log_error("Error removing %s file '%s': %s" % (ptype, profile_path, e))
+            _log_error("Error removing %s file '%s': %s", ptype, profile_path, e)
 
     def delete_profile(self):
         """Delete on-disk data for this profile.
@@ -1369,7 +1376,7 @@ class OsProfile(BoomProfile):
         """
         err_str = "Invalid profile data (missing %s)"
 
-        _log_debug_profile("Initialising OsProfile from profile_data=%s" % profile_data)
+        _log_debug_profile("Initialising OsProfile from profile_data=%s", profile_data)
 
         # Set profile defaults
         for key in _DEFAULT_KEYS:
@@ -1427,7 +1434,7 @@ class OsProfile(BoomProfile):
         comment = ""
         ptype = self.__class__.__name__
 
-        _log_debug("Loading %s from '%s'" % (ptype, basename(profile_file)))
+        _log_debug("Loading %s from '%s'", ptype, basename(profile_file))
         with open(profile_file, "r") as pf:
             for line in pf:
                 if blank_or_comment(line):

--- a/boom/stratis.py
+++ b/boom/stratis.py
@@ -68,7 +68,7 @@ def pool_name_to_pool_uuid(pool_name):
     """
     bus = dbus.SystemBus()
     _log_debug_stratis(
-        "Connecting to %s at %s via system bus" % (_STRATISD_SERVICE, _STRATISD_PATH)
+        "Connecting to %s at %s via system bus", (_STRATISD_SERVICE, _STRATISD_PATH)
     )
     proxy = bus.get_object(_STRATISD_SERVICE, _STRATISD_PATH, introspect=False)
     object_manager = dbus.Interface(proxy, _DBUS_OBJECT_MANAGER_IFACE)
@@ -83,8 +83,9 @@ def pool_name_to_pool_uuid(pool_name):
         raise IndexError("Stratis pool '%s' not found" % pool_name)
     pool_uuid = str(props["Uuid"])
     _log_debug(
-        "Looked up pool_uuid=%s for Stratis pool %s"
-        % (format_pool_uuid(pool_uuid), pool_name)
+        "Looked up pool_uuid=%s for Stratis pool %s",
+        format_pool_uuid(pool_uuid),
+        pool_name,
     )
     return pool_uuid
 


### PR DESCRIPTION
Fixes pylint W1201: Use lazy % formatting in logging functions (logging-not-lazy).