### PR TITLE
dist: replace license classifier with SPDX expression in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "boom_boot"
 version = "1.6.5"
-license = { file="COPYING" }
+license = { text="GPL-2.0-only" }
 authors = [
   { name="Bryn M. Reeves", email="bmr@redhat.com" },
 ]
@@ -12,7 +12,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: Implementation :: CPython",
@@ -26,5 +25,8 @@ Homepage = "https://github.com/snapshotmanager/boom-boot"
 Issues = "https://github.com/snapshotmanager/boom-boot/issues"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = [
+    "wheel",
+    "setuptools>=61.0"
+]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,8 +4,7 @@ author = Bryn M. Reeves
 author_email = bmr@redhat.com
 url = https://github.com/snapshotmanager/boom
 description = The Boom Boot Manager
-license = GPL-2.0-only
-license_file = COPYING
+license = "GPL-2.0-only"
 long_description = file: README.md
 long_description_content_type = text/markdown
 version = attr: boom.__version__
@@ -15,7 +14,6 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
     Intended Audience :: System Administrators
-    License :: OSI Approved :: GNU General Public License v2 (GPLv2)
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: Implementation :: CPython


### PR DESCRIPTION
Avoids:

  ********************************************************************************
  Please consider removing the following classifiers in favor of a SPDX license expression:

  License :: OSI Approved :: GNU General Public License v2 (GPLv2)

  See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
  ********************************************************************************

Resolves: #82