### PR TITLE
Drop remaining python2 compat handling

### DIFF
--- a/boom/config.py
+++ b/boom/config.py
@@ -17,17 +17,11 @@ from __future__ import print_function
 from os.path import dirname
 
 from os import fdopen, rename, chmod, fdatasync
+from configparser import ConfigParser, ParsingError
 from tempfile import mkstemp
 import logging
 
 from boom import *
-
-try:
-    # Python2
-    from ConfigParser import SafeConfigParser as ConfigParser, ParsingError
-except ImportError:
-    # Python3
-    from configparser import ConfigParser, ParsingError
 
 
 class BoomConfigError(BoomError):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -10,15 +10,10 @@ import logging
 from sys import stdout
 from os import listdir, makedirs, unlink
 from os.path import abspath, basename, dirname, exists, join
+from io import StringIO
 from glob import glob
 import shutil
 import re
-
-# Python3 moves StringIO to io
-try:
-    from StringIO import StringIO
-except:
-    from io import StringIO
 
 log = logging.getLogger()
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -10,15 +10,10 @@ import logging
 from sys import stdout
 from os import listdir, makedirs
 from os.path import abspath, basename, dirname, exists, join
+from io import StringIO
 from glob import glob
 import shutil
 import re
-
-# Python3 moves StringIO to io
-try:
-    from StringIO import StringIO
-except:
-    from io import StringIO
 
 log = logging.getLogger()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,16 +7,11 @@
 # SPDX-License-Identifier: GPL-2.0-only
 import unittest
 import logging
+from configparser import ConfigParser, ParsingError
 from os.path import abspath, join
 from sys import stdout
 import shutil
 
-try:
-    # Python2
-    from ConfigParser import SafeConfigParser as ConfigParser, ParsingError
-except:
-    # Python3
-    from configparser import ConfigParser, ParsingError
 
 log = logging.getLogger()
 

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -10,15 +10,10 @@ import logging
 from sys import stdout
 from os import listdir, makedirs, unlink
 from os.path import abspath, basename, dirname, exists, join
+from io import StringIO
 from glob import glob
 import shutil
 import re
-
-# Python3 moves StringIO to io
-try:
-    from StringIO import StringIO
-except:
-    from io import StringIO
 
 log = logging.getLogger()
 


### PR DESCRIPTION
Remove the last few instances from `boom.config` and the test suite.

Resolves: #97, #98, #99.