### PR TITLE
dist: avoid Python packaging warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "boom_boot"
 version = "1.6.6"
-license = { text="GPL-2.0-only" }
 authors = [
   { name="Bryn M. Reeves", email="bmr@redhat.com" },
 ]
 description = "The Boom Boot Manager"
 readme = "README.md"
 requires-python = ">=3.6"
+dynamic = ["license"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",


### PR DESCRIPTION
  ********************************************************************************
  Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

  By 2026-Feb-18, you need to update your project and remove deprecated calls
  or your builds will no longer be supported.

  See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
  ********************************************************************************

~~We can't use a simple string since that breaks downstream builds on distributions that do not yet support PEP639. For now switch to using license-files in pyproject.toml and setup.cfg.~~

We can't switch to using `license-files` in pyproject.toml because that breaks all down stream builds newer than epel-9.

Referring to pypa/packaging-problems#870 the current solution seems to be to drop `license` and `license-files` completely from pyproject.toml, add `dynamic = ["license"]` and keeping the license key in `setup.cfg`.

See also snapshotmanager/snapm#142

Resolves: #102