### PR TITLE
tests: rename BadConfigTests.test_load_boom_config_default

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -118,8 +118,8 @@ class BadConfigTests(ConfigTests):
     # The set of configuration files to use for this test class
     conf_path = join(BOOT_ROOT_TEST, "boom_configs/badconfig/boot")
 
-    def test_load_boom_config_default(self):
-        """Test the `load_boom_config()` function with the default
+    def test_load_boom_config_invalid_raises(self):
+        """Test the `load_boom_config()` function with an invalid
             configuration file.
         """
         with self.assertRaises(ValueError) as cm:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,7 +63,7 @@ class ConfigBasicTests(unittest.TestCase):
         self.assertEqual(cfg.get("global", "boom_root"), boom_path)
 
 
-class ConfigTests(unittest.TestCase):
+class ConfigTestsBase(unittest.TestCase):
     # The set of configuration files to use for this test class
     conf_path = join(BOOT_ROOT_TEST, "boom_configs/default/boot")
 
@@ -91,6 +91,8 @@ class ConfigTests(unittest.TestCase):
         rm_sandbox()
         reset_boom_paths()
 
+
+class ConfigTests(ConfigTestsBase):
     def test_get_boom_config_path(self):
         """Test that the correct boom.conf path is returned from a call
             to the `get_boom_config_path()` function.
@@ -114,7 +116,7 @@ class ConfigTests(unittest.TestCase):
         """
         load_boom_config()
 
-class BadConfigTests(ConfigTests):
+class BadConfigTests(ConfigTestsBase):
     # The set of configuration files to use for this test class
     conf_path = join(BOOT_ROOT_TEST, "boom_configs/badconfig/boot")
 


### PR DESCRIPTION
This name mirrors the name of `ConfigTests.test_load_boom_config_default` and is potentially confusing: the test is explicitly loading an invalid configuration to verify that a `ValueError` exception is properly raised:

```
  $ pytest -v --log-level=debug -k test_load_boom_config_invalid_raises
  ============================= test session starts ==============================
  platform linux -- Python 3.13.2, pytest-8.3.4, pluggy-1.5.0 -- /usr/bin/python3
  cachedir: .pytest_cache
  rootdir: /home/breeves/src/git/boom-boot
  configfile: pyproject.toml
  plugins: subtests-0.12.1
  collected 447 items / 446 deselected / 1 selected

  tests/test_config.py::BadConfigTests::test_load_boom_config_invalid_raises PASSED [100%]

  ====================== 1 passed, 446 deselected in 0.13s =======================
```

Resolves: #122