### PR TITLE
tests: use `log.info()` for test log messages instead of `log.debug()`

### DIFF
--- a/tests/test_boom.py
+++ b/tests/test_boom.py
@@ -22,10 +22,10 @@ boom.set_boot_path(BOOT_ROOT_TEST)
 
 class BoomTests(unittest.TestCase):
     def setUp(self):
-        log.debug("Preparing %s", self._testMethodName)
+        log.info("Preparing %s", self._testMethodName)
 
     def tearDown(self):
-        log.debug("Tearing down %s", self._testMethodName)
+        log.info("Tearing down %s", self._testMethodName)
 
     # Module tests
     def test_import(self):
@@ -232,10 +232,10 @@ class BoomTests(unittest.TestCase):
 
 class BoomPathTests(unittest.TestCase):
     def setUp(self):
-        log.debug("Preparing %s", self._testMethodName)
+        log.info("Preparing %s", self._testMethodName)
 
     def tearDown(self):
-        log.debug("Tearing down %s", self._testMethodName)
+        log.info("Tearing down %s", self._testMethodName)
 
     def test_set_boot_path(self):
         boom.set_boot_path(BOOT_ROOT_TEST)

--- a/tests/test_bootloader.py
+++ b/tests/test_bootloader.py
@@ -34,10 +34,10 @@ _test_osp = None
 
 class BootParamsTests(unittest.TestCase):
     def setUp(self):
-        log.debug("Preparing %s", self._testMethodName)
+        log.info("Preparing %s", self._testMethodName)
 
     def tearDown(self):
-        log.debug("Tearing down %s", self._testMethodName)
+        log.info("Tearing down %s", self._testMethodName)
 
     def test_BootParams_no_version_raises(self):
         with self.assertRaises(ValueError) as cm:
@@ -180,7 +180,7 @@ class BootEntryBasicTests(unittest.TestCase):
     boom_path = join(BOOT_ROOT_TEST, "boom")
 
     def setUp(self):
-        log.debug("Preparing %s", self._testMethodName)
+        log.info("Preparing %s", self._testMethodName)
         reset_sandbox()
 
         # Sandbox paths
@@ -202,7 +202,7 @@ class BootEntryBasicTests(unittest.TestCase):
         load_host_profiles()
 
     def tearDown(self):
-        log.debug("Tearing down %s", self._testMethodName)
+        log.info("Tearing down %s", self._testMethodName)
         # Drop any in-memory entries and profiles modified by tests
         drop_entries()
         drop_profiles()
@@ -368,7 +368,7 @@ class BootEntryTests(unittest.TestCase):
             Defines standard OsProfile, BootParams, and BootEntry
             objects for use in these tests.
         """
-        log.debug("Preparing %s", self._testMethodName)
+        log.info("Preparing %s", self._testMethodName)
 
         reset_sandbox()
 
@@ -419,7 +419,7 @@ class BootEntryTests(unittest.TestCase):
         """Tear down the standard test profiles and entries used by the
             BootEntryTests class.
         """
-        log.debug("Tearing down %s", self._testMethodName)
+        log.info("Tearing down %s", self._testMethodName)
 
         # Drop any in-memory entries and profiles modified by tests
         drop_entries()
@@ -968,10 +968,10 @@ class BootEntryTests(unittest.TestCase):
 
 class BootLoaderBasicTests(unittest.TestCase):
     def setUp(self):
-        log.debug("Preparing %s", self._testMethodName)
+        log.info("Preparing %s", self._testMethodName)
 
     def tearDown(self):
-        log.debug("Tearing down %s", self._testMethodName)
+        log.info("Tearing down %s", self._testMethodName)
 
     def test_import(self):
         import boom.bootloader
@@ -995,7 +995,7 @@ class BootLoaderTests(unittest.TestCase):
             Defines standard OsProfile, BootParams, and BootEntry
             objects for use in these tests.
         """
-        log.debug("Preparing %s", self._testMethodName)
+        log.info("Preparing %s", self._testMethodName)
 
         reset_sandbox()
 
@@ -1021,7 +1021,7 @@ class BootLoaderTests(unittest.TestCase):
             Tear down the standard test profiles and entries used by the
             BootEntryTests class.
         """
-        log.debug("Tearing down %s", self._testMethodName)
+        log.info("Tearing down %s", self._testMethodName)
 
         # Drop any in-memory entries and profiles modified by tests
         drop_entries()
@@ -1104,7 +1104,7 @@ class BootLoaderTestsCheckRoot(unittest.TestCase):
     del_devs = []
 
     def setUp(self):
-        log.debug("Preparing %s", self._testMethodName)
+        log.info("Preparing %s", self._testMethodName)
         reset_sandbox()
         dev_path = join(SANDBOX_PATH, "dev")
         makedirs(dev_path)
@@ -1123,7 +1123,7 @@ class BootLoaderTestsCheckRoot(unittest.TestCase):
                     raise
 
     def tearDown(self):
-        log.debug("Tearing down %s", self._testMethodName)
+        log.info("Tearing down %s", self._testMethodName)
 
         rm_sandbox()
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -51,13 +51,13 @@ class CacheHelperTests(unittest.TestCase):
     def setUp(self):
         """Set up a test fixture for the CacheHelperTests class.
         """
-        log.debug("Preparing %s", self._testMethodName)
+        log.info("Preparing %s", self._testMethodName)
 
         set_boom_config(config)
         set_boot_path(BOOT_ROOT_TEST)
 
     def tearDown(self):
-        log.debug("Tearing down %s", self._testMethodName)
+        log.info("Tearing down %s", self._testMethodName)
 
         # Drop any in-memory entries and profiles modified by tests
         drop_entries()
@@ -118,7 +118,7 @@ class CacheTests(unittest.TestCase):
 
             Defines standard objects for use in these tests.
         """
-        log.debug("Preparing %s", self._testMethodName)
+        log.info("Preparing %s", self._testMethodName)
 
         reset_sandbox()
 
@@ -163,7 +163,7 @@ class CacheTests(unittest.TestCase):
         load_cache()
 
     def tearDown(self):
-        log.debug("Tearing down %s", self._testMethodName)
+        log.info("Tearing down %s", self._testMethodName)
 
         # Drop any in-memory entries and profiles modified by tests
         drop_entries()

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -42,10 +42,10 @@ debug_masks = ['profile', 'entry', 'report', 'command', 'all']
 
 class CommandHelperTests(unittest.TestCase):
     def setUp(self):
-        log.debug("Preparing %s", self._testMethodName)
+        log.info("Preparing %s", self._testMethodName)
 
     def tearDown(self):
-        log.debug("Tearing down %s", self._testMethodName)
+        log.info("Tearing down %s", self._testMethodName)
 
     """Test internal boom.command helpers: methods in this part of the
         test suite import boom.command directly in order to access the
@@ -282,7 +282,7 @@ class CommandTests(unittest.TestCase):
 
             Defines standard objects for use in these tests.
         """
-        log.debug("Preparing %s", self._testMethodName)
+        log.info("Preparing %s", self._testMethodName)
 
         reset_sandbox()
 
@@ -326,7 +326,7 @@ class CommandTests(unittest.TestCase):
         load_host_profiles()
 
     def tearDown(self):
-        log.debug("Tearing down %s", self._testMethodName)
+        log.info("Tearing down %s", self._testMethodName)
 
         # Drop any in-memory entries and profiles modified by tests
         drop_entries()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,10 +28,10 @@ class ConfigBasicTests(unittest.TestCase):
     """
 
     def setUp(self):
-        log.debug("Preparing %s", self._testMethodName)
+        log.info("Preparing %s", self._testMethodName)
 
     def tearDown(self):
-        log.debug("Tearing down %s", self._testMethodName)
+        log.info("Tearing down %s", self._testMethodName)
 
     def test_sync_config(self):
         """Test that the internal _sync_config() helper works.
@@ -76,7 +76,7 @@ class ConfigTestsBase(unittest.TestCase):
     def setUp(self):
         """Set up a test fixture for the ConfigTests class.
         """
-        log.debug("Preparing %s", self._testMethodName)
+        log.info("Preparing %s", self._testMethodName)
 
         reset_sandbox()
 
@@ -86,7 +86,7 @@ class ConfigTestsBase(unittest.TestCase):
         set_boot_path(self.boot_path)
 
     def tearDown(self):
-        log.debug("Tearing down %s", self._testMethodName)
+        log.info("Tearing down %s", self._testMethodName)
 
         rm_sandbox()
         reset_boom_paths()

--- a/tests/test_hostprofile.py
+++ b/tests/test_hostprofile.py
@@ -80,7 +80,7 @@ class HostProfileTests(unittest.TestCase):
     loader_path = join(BOOT_ROOT_TEST, "loader")
 
     def setUp(self):
-        log.debug("Preparing %s", self._testMethodName)
+        log.info("Preparing %s", self._testMethodName)
 
         reset_sandbox()
 
@@ -99,7 +99,7 @@ class HostProfileTests(unittest.TestCase):
         drop_profiles()
 
     def tearDown(self):
-        log.debug("Tearing down %s", self._testMethodName)
+        log.info("Tearing down %s", self._testMethodName)
 
         drop_host_profiles()
         drop_profiles()

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -32,10 +32,10 @@ class MountsHelperTests(unittest.TestCase):
         fixture.
     """
     def setUp(self):
-        log.debug("Preparing %s", self._testMethodName)
+        log.info("Preparing %s", self._testMethodName)
 
     def tearDown(self):
-        log.debug("Tearing down %s", self._testMethodName)
+        log.info("Tearing down %s", self._testMethodName)
 
     def test_parse_mount_units(self):
         mount_list = ["/dev/test/var:/var:xfs:defaults"]

--- a/tests/test_osprofile.py
+++ b/tests/test_osprofile.py
@@ -30,7 +30,7 @@ class OsProfileTests(unittest.TestCase):
     boom_path = join(BOOT_ROOT_TEST, "boom")
 
     def setUp(self):
-        log.debug("Preparing %s", self._testMethodName)
+        log.info("Preparing %s", self._testMethodName)
 
         reset_sandbox()
 
@@ -46,7 +46,7 @@ class OsProfileTests(unittest.TestCase):
         drop_profiles()
 
     def tearDown(self):
-        log.debug("Tearing down %s", self._testMethodName)
+        log.info("Tearing down %s", self._testMethodName)
 
         drop_profiles()
         rm_sandbox()

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -95,10 +95,10 @@ _test_obj_types = [
 
 class ReportTests(unittest.TestCase):
     def setUp(self):
-        log.debug("Preparing %s", self._testMethodName)
+        log.info("Preparing %s", self._testMethodName)
 
     def tearDown(self):
-        log.debug("Tearing down %s", self._testMethodName)
+        log.info("Tearing down %s", self._testMethodName)
 
     def test_FieldType_no_type(self):
         with self.assertRaises(ValueError):

--- a/tests/test_stratis.py
+++ b/tests/test_stratis.py
@@ -34,10 +34,10 @@ class StratisTests(unittest.TestCase):
         test data.
     """
     def setUp(self):
-        log.debug("Preparing %s", self._testMethodName)
+        log.info("Preparing %s", self._testMethodName)
 
     def tearDown(self):
-        log.debug("Tearing down %s", self._testMethodName)
+        log.info("Tearing down %s", self._testMethodName)
 
     # Stratis module tests
 


### PR DESCRIPTION
Make the messages that bracket each test case more prominent in the resulting logs:

```
2025-04-07 17:56:47,937 INFO root Preparing test_load_boom_config_invalid_raises
2025-04-07 17:56:47,940 INFO root Tearing down test_load_boom_config_invalid_raises
```

vs:

```
2025-04-07 17:56:47,937 DEBUG root Preparing test_load_boom_config_invalid_raises
2025-04-07 17:56:47,940 DEBUG root Tearing down test_load_boom_config_invalid_raises
```

This is particularly useful with tools that highlight or colourize logs based on the log level.

Resolves: #125