### PR TITLE
Do not require wheel for building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ Issues = "https://github.com/snapshotmanager/boom-boot/issues"
 
 [build-system]
 requires = [
-    "wheel",
     "setuptools>=61.0"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
 - current version of setuptools (70.1+) does not need wheel at all
 - older versions of setuptools would fetch wheel when building wheels (but not sdists)