### PR TITLE
boom: make environment helpers public

### DIFF
--- a/boom/command.py
+++ b/boom/command.py
@@ -679,7 +679,7 @@ _default_cache_fields = "path,imgid,ts,state"
 _verbose_cache_fields = "path,imgid,ts,mode,uid,gid,state,count"
 
 
-def _get_machine_id():
+def get_machine_id():
     """Return the current host's machine-id.
 
     Get the machine-id value for the running system by reading from
@@ -2553,7 +2553,7 @@ def _create_cmd(cmd_args, _select, _opts, identifier):
 
     if not cmd_args.machine_id:
         # Use host machine-id by default
-        machine_id = _get_machine_id()
+        machine_id = get_machine_id()
         if not machine_id:
             print("Could not determine machine_id")
             return 1
@@ -3283,7 +3283,7 @@ def _create_host_cmd(cmd_args, _select, _opts, identifier):
 
     if not cmd_args.machine_id:
         # Use host machine-id by default
-        machine_id = _get_machine_id()
+        machine_id = get_machine_id()
         if not machine_id:
             print("Could not determine machine_id")
             return 1
@@ -4311,6 +4311,9 @@ __all__ = [
     "I_NONE",
     "I_CACHE",
     "I_BACKUP",
+    # Environment
+    "get_machine_id",
+    "get_uts_release",
 ]
 
 # vim: set et ts=4 sw=4 :

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -166,10 +166,10 @@ class CommandHelperTests(unittest.TestCase):
         boom.command.show_legacy()
 
     @unittest.skip("No machine_id available in CI")
-    def test__get_machine_id(self):
+    def test_get_machine_id(self):
         # FIXME: does not cover _DBUS_MACHINE_ID hosts or exceptions
         # reading /etc/machine-id.
-        machine_id = boom.command._get_machine_id()
+        machine_id = boom.command.get_machine_id()
         self.assertTrue(machine_id)
 
     def test__merge_add_del_opts_no_op(self):


### PR DESCRIPTION
The functions get_machine_id() and get_uts_release() are useful to users of the boom.command module: make them public and part of the __all__ list.

Resolves: #76