### PR TITLE
boom: make exit status and usage messages consistent

### DIFF
--- a/boom/command.py
+++ b/boom/command.py
@@ -4347,6 +4347,10 @@ def main(args: List[str]) -> int:
         help="The kernel version of a boom boot entry",
     )
 
+    # Special case: allow -h/--help to work even if type/command are omitted.
+    if any(a in ("-h", "--help") for a in args[1:]):
+        parser.print_help()
+        return 0
     if len(args) < 3:
         parser.error("too few arguments")
 

--- a/boom/command.py
+++ b/boom/command.py
@@ -4356,9 +4356,7 @@ def main(args: List[str]) -> int:
     )
 
     if len(args) < 3:
-        parser.print_usage()
-        print(f"Too few arguments: {' '.join(args[1:])}")
-        return 1
+        parser.error("too few arguments")
 
     cmd_types = [cmdtype[0] for cmdtype in _boom_command_types]
     cmd_verbs = _get_command_verbs()
@@ -4367,9 +4365,7 @@ def main(args: List[str]) -> int:
     cmd_arg = args[2] if len(args) > 2 else ""
 
     if type_arg not in cmd_types or cmd_arg not in cmd_verbs:
-        parser.print_usage()
-        print(f"Unknown command: {type_arg} {cmd_arg}")
-        return 1
+        parser.error(f"unknown command: {type_arg} {cmd_arg}")
 
     cmd_args = parser.parse_args(args=args[1:])
 
@@ -4381,8 +4377,7 @@ def main(args: List[str]) -> int:
     setup_logging(cmd_args)
     cmd_type = _match_cmd_type(cmd_args.type)
     if not cmd_type:
-        print(f"Unknown command type: {cmd_args.type}")
-        return 1
+        parser.error(f"unknown command type: {cmd_args.type}")
 
     if cmd_args.boot_dir or BOOM_BOOT_PATH_ENV in environ:
         boot_path = cmd_args.boot_dir or environ[BOOM_BOOT_PATH_ENV]
@@ -4464,8 +4459,7 @@ def main(args: List[str]) -> int:
     type_cmds = cmd_type[1]
     command = _match_command(cmd_args.command, type_cmds)
     if not command:
-        print(f"Unknown command: {cmd_type[0]} {cmd_args.command}")
-        return 1
+        parser.error(f"unknown command: {cmd_type[0]} {cmd_args.command}")
 
     if cmd_args.backup and not bc.cache_enable:
         print("--backup specified but cache disabled (config.cache_enable=False)")

--- a/boom/command.py
+++ b/boom/command.py
@@ -3912,10 +3912,8 @@ def _id_from_arg(cmd_args: Namespace, cmdtype: str, cmd: str) -> Optional[str]:
 
 
 def _match_cmd_type(cmdtype: str):
-    for t in _boom_command_types:
-        if t[0].startswith(cmdtype):
-            return t
-    return None
+    matches = [t for t in _boom_command_types if t[0] == cmdtype]
+    return matches[0] if len(matches) == 1 else None
 
 
 def _match_command(cmd: str, cmds):

--- a/boom/command.py
+++ b/boom/command.py
@@ -4371,14 +4371,7 @@ def main(args: List[str]) -> int:
         print(f"Unknown command: {type_arg} {cmd_arg}")
         return 1
 
-    try:
-        cmd_args = parser.parse_args(args=args[1:])
-    except SystemExit as e:
-        if not e.code:
-            return 0
-        if isinstance(e.code, int):
-            return e.code
-        return 1
+    cmd_args = parser.parse_args(args=args[1:])
 
     try:
         set_debug(cmd_args.debug)

--- a/boom/command.py
+++ b/boom/command.py
@@ -3981,6 +3981,13 @@ def set_debug(debug_arg: None):
 
 def main(args: List[str]) -> int:
     parser = ArgumentParser(prog=basename(args[0]), description="Boom Boot Manager")
+    # Derive help text from registered command types/commands
+    type_choices_list = sorted(t[0] for t in _boom_command_types)
+    type_choices = ", ".join(type_choices_list)
+    cmd_help_by_type = "; ".join(
+        f"{t}=[{', '.join(sorted(cmd for (cmd, _) in cmds))}]"
+        for (t, cmds) in _boom_command_types
+    )
 
     # Default type is boot entry.
     if len(args) > 1 and _match_command(args[1], _boom_entry_commands):
@@ -3988,9 +3995,11 @@ def main(args: List[str]) -> int:
 
     parser.add_argument(
         "type",
-        metavar="[TYPE]",
+        metavar="TYPE",
         type=str,
-        help="The command type to run: profile or entry",
+        help=(
+            f"The command type to run: {type_choices}. Defaults to 'entry' for known entry commands."
+        ),
         action="store",
     )
     parser.add_argument(
@@ -3998,7 +4007,7 @@ def main(args: List[str]) -> int:
         metavar="COMMAND",
         type=str,
         action="store",
-        help="The command to run: create, delete, list, edit, clone, show",
+        help=f"The command to run; by TYPE: {cmd_help_by_type}",
     )
     parser.add_argument(
         "identifier",

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -2353,10 +2353,14 @@ class CommandTests(unittest.TestCase):
         status = boom.command.main(args)
         self.assertEqual(status, 0)
 
+    def test_boom_main_help(self):
+        args = ['bin/boom', '--help']
+        status = boom.command.main(args)
+        self.assertEqual(status, 0)
+
     def test_boom_main_argument_errors(self):
         cases = [
             ["bin/boom",],
-            ["bin/boom", "--help"],
             ["bin/boom", "quux", "list"],
             ["bin/boom", "entry", "quux"],
             ["bin/boom", "entry", "create", "--quux", "--title", "FOO"],

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -2353,6 +2353,11 @@ class CommandTests(unittest.TestCase):
         status = boom.command.main(args)
         self.assertEqual(status, 0)
 
+    def test_boom_main_list_no_type(self):
+        args = ['bin/boom', 'list']
+        status = boom.command.main(args)
+        self.assertEqual(status, 0)
+
     def test_boom_main_help(self):
         args = ['bin/boom', '--help']
         status = boom.command.main(args)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -2348,12 +2348,23 @@ class CommandTests(unittest.TestCase):
         args = MockArgs()
         r = boom.command._show_cache_cmd(args, None, None, None)
 
-    def test_boom_main_noargs(self):
-        args = ['bin/boom', '--help']
-        boom.command.main(args)
-
     def test_boom_main_list(self):
         args = ['bin/boom', 'entry', 'list']
-        boom.command.main(args)
+        status = boom.command.main(args)
+        self.assertEqual(status, 0)
+
+    def test_boom_main_argument_errors(self):
+        cases = [
+            ["bin/boom",],
+            ["bin/boom", "--help"],
+            ["bin/boom", "quux", "list"],
+            ["bin/boom", "entry", "quux"],
+            ["bin/boom", "entry", "create", "--quux", "--title", "FOO"],
+        ]
+        for args in cases:
+            with self.subTest(args=args):
+                with self.assertRaises(SystemExit) as cm:
+                    boom.command.main(args)
+                self.assertEqual(cm.exception.code, 2)
 
 # vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Right now we exit with status 1 if the command is unknown:

```bash
  # boom quux create --title foo --root-lv fedora/root
  usage: boom [-h] [-a OPTIONS] [--all] [--architecture ARCH] [--backup] [-b BOOT_ID] [--boot-dir PATH] [-B SUBVOL] [--btrfs-opts OPTS] [-c FILE] [-d OPTIONS] [--debug DEBUGOPTS] [-e IMG]
              [-E] [--grub-arg ARGS] [--grub-class CLASS] [--grub-users USERS] [--grub-id ID] [-H] [-P PROFILE] [--host-name HOSTNAME] [-i IMG] [-k PATTERN] [--label LABEL] [-l IMG] [-L LV]
              [--lvm-opts OPTS] [-m MACHINE_ID] [-M MOUNT] [-n OSNAME] [--name-prefixes] [--no-headings] [--no-dev] [--no-fstab] [--optional-keys KEYS] [-o FIELDS] [--os-version OSVERSION]
              [-O SORTFIELDS] [-I OSVERSIONID] [--os-options OPTIONS] [--os-release OSRELEASE] [-p OS_ID] [-r ROOT] [-R PATTERN] [--json | --rows] [--separator SEP] [-s OSSHORTNAME]
              [--swap SWAP] [-t TITLE] [-u PATTERN] [--update] [-V] [-v VERSION]
              [TYPE] COMMAND [ID]
  Unknown command: quux create
  # echo $?
  1
```

This is confusing and inconsistent: "1" means "runtime/logic error" (boom could not complete what was asked). ArgumentParser uses "2" for "unrecognised argument", so let's go with that for consistency:


```bash
  # boom quux create --title foo ---root-lv fedora/root
  usage: boom [-h] [-a OPTIONS] [--all] [--architecture ARCH] [--backup] [-b BOOT_ID] [--boot-dir PATH] [-B SUBVOL] [--btrfs-opts OPTS] [-c FILE] [-d OPTIONS] [--debug DEBUGOPTS] [-e IMG]
              [-E] [--grub-arg ARGS] [--grub-class CLASS] [--grub-users USERS] [--grub-id ID] [-H] [-P PROFILE] [--host-name HOSTNAME] [-i IMG] [-k PATTERN] [--label LABEL] [-l IMG] [-L LV]
              [--lvm-opts OPTS] [-m MACHINE_ID] [-M MOUNT] [-n OSNAME] [--name-prefixes] [--no-headings] [--no-dev] [--no-fstab] [--optional-keys KEYS] [-o FIELDS] [--os-version OSVERSION]
              [-O SORTFIELDS] [-I OSVERSIONID] [--os-options OPTIONS] [--os-release OSRELEASE] [-p OS_ID] [-r ROOT] [-R PATTERN] [--json | --rows] [--separator SEP] [-s OSSHORTNAME]
              [--swap SWAP] [-t TITLE] [-u PATTERN] [--update] [-V] [-v VERSION]
              [TYPE] COMMAND [ID]
  Unknown command: quux create
  root@f42-snapm-vm1:~/src/git/boom-boot# echo $?
  2
```

Resolves: #178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI now requires exact type/command matches and reports unknown invocations as formal errors (usage + exit code 2); conflicting root options and validation errors are flagged earlier.

* **New Features**
  * Help output now lists available types and commands and works without specifying type/command.
  * Logical-volume/device inputs are canonicalized and normalized during invocation for consistent handling.

* **Tests**
  * Tests updated to assert success (0) for help/list and SystemExit (2) for invalid cases; coverage improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->