### PR TITLE
doc: apply CSS workaround for Sphinx docs sidebar overflow

### DIFF
--- a/doc/_static/css/workaround.css
+++ b/doc/_static/css/workaround.css
@@ -1,0 +1,10 @@
+div.documentwrapper div.bodywrapper { margin-left: 350px;}
+div.document div.sphinxsidebar { width: 350px; }
+
+div.sphinxsidebarwrapper {
+    overflow-y: auto;
+    overflow-x: hidden;
+    max-height: 100vh;
+    overscroll-behavior: contain;
+    word-break: break-word; /* or: overflow-wrap: anywhere; */
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -343,3 +343,8 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #
 # texinfo_no_detailmenu = False
+
+# Work around sidebar overflow (#197)
+html_css_files = [
+    'css/workaround.css'
+]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -73,7 +73,7 @@ release = u'1.6.6'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ Issues = "https://github.com/snapshotmanager/boom-boot/issues"
 
 [build-system]
 requires = [
-    "setuptools>=61.0"
+    "setuptools>=61.0",
 ]
 build-backend = "setuptools.build_meta"
+
+[project.optional-dependencies]
+docs = ["Sphinx>=1.8"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pycodestyle>=2.4.0
 coverage>=4.0.3
-Sphinx>=1.3.5
+Sphinx>=1.8
 dbus-python>=1.2.16


### PR DESCRIPTION
Resolves: #197 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Set default documentation language to English for consistent content, indexing, and translations.
  * Added stylesheet tweaks to improve HTML docs layout and sidebar behavior across devices.

* **Bug Fixes**
  * Fixed sidebar overflow and layout issues so the sidebar scrolls properly and content no longer overlaps.

* **Chores**
  * Raised the minimum Sphinx requirement to ensure compatibility with updated docs features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->