### PR TITLE
boom: fix typos in source and documentation

### DIFF
--- a/boom/command.py
+++ b/boom/command.py
@@ -1005,7 +1005,7 @@ def _find_one_entry(select: Selection) -> BootEntry:
     """Find exactly one entry, and raise ValueError if zero or more
     than one entry is found.
 
-    :param: An instance of ``Selection`` specificying match criteria.
+    :param select: An instance of ``Selection`` specifying match criteria.
     :returns: A single instance of ``BootEntry``
     :raises: ValueError if selection results are empty or non-unique
     """
@@ -1107,7 +1107,7 @@ def create_entry(
     :param allow_no_dev: Accept a non-existent or invalid root dev.
     :param images: Whether to cache or backup boot images in the new
                    entry.
-    :param update: Whether to update or re-use an existing cached
+    :param update: Whether to update or reuse an existing cached
                    boot image.
     :param no_fstab: Disable parsing of the fstab for the new entry.
     :param mounts: A list of colon separated command-line mount
@@ -1276,7 +1276,7 @@ def clone_entry(
     :param allow_no_dev: Allow the block device to not exist.
     :param images: Whether to cache or backup boot images in the new
                    entry.
-    :param update: Whether to update or re-use an existing cached boot
+    :param update: Whether to update or reuse an existing cached boot
                    image.
     :param no_fstab: Disable parsing of the fstab for the new entry.
     :param mounts: A list of colon-separated command-line mount

--- a/man/man8/boom.8
+++ b/man/man8/boom.8
@@ -973,7 +973,7 @@ graphical boot or the "quiet" flag for a particular entry).
 If \fB--backup\fP is given a backup is made of the boot images (vmlinuz
 and initramfs) used by the boot entry and the new entry will use the
 backup paths instead of the original image paths. By default if an
-existing backup image is present it will be re-used instead of using the
+existing backup image is present it will be reused instead of using the
 latest matching image found in the boot directory. This behaviour can be
 overridden by using the \fB--update\fP option.
 .IP
@@ -1020,7 +1020,7 @@ to the original entry.
 If \fB--backup\fP is given a backup is made of the boot images (vmlinuz
 and initramfs) used by the boot entry and the new entry will use the
 backup paths instead of the original image paths. By default if an
-existing backup image is present it will be re-used instead of using the
+existing backup image is present it will be reused instead of using the
 latest matching image found in the boot directory. This behaviour can be
 overridden by using the \fB--update\fP option.
 .IP


### PR DESCRIPTION
Resolves: #365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected typos and standardized wording (e.g., “re-use/re-used” → “reuse/reused”) across help text and manual.
  * Clarified parameter descriptions and phrasing (including clearer reference to the boot image) for improved accuracy and readability.
  * Refined the --backup option wording in Boot Entry Create/Clone documentation.
  * Editorial changes only; no functional behavior or interfaces were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->